### PR TITLE
Finalize initial compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
+.phpcs.cache
 vendor/
-.php-cs-fixer.cache

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "laminas/laminas-coding-standard": "~2.1.0"
     },
     "autoload": {
-        "classmap": [
-            "src/ZendJobQueue.php"
+        "files": [
+            "src/autoload.php"
         ]
     },
     "provide": {

--- a/composer.json
+++ b/composer.json
@@ -1,34 +1,46 @@
 {
-  "name":         "zendps/zs-jobqueue-compat",
-  "description":  "Compatibility for Zend Server Job Queue",
-  "keywords": [
-    "zend",
-    "zend server",
-    "job queue",
-    "zs",
-    "jq"
-  ],
-  "license":      "MIT",
-  "type":         "library",
-  "authors": [
-    {
-      "name":     "Slavey Karadzhov",
-      "email":    "skaradzhov@perforce.com"
+    "name": "zendps/zs-jobqueue-compat",
+    "description": "Compatibility for Zend Server Job Queue",
+    "keywords": [
+        "zend",
+        "zend server",
+        "job queue",
+        "zs",
+        "jq"
+    ],
+    "license": "MIT",
+    "type": "library",
+    "authors": [
+        {
+            "name":     "Slavey Karadzhov",
+            "email":    "skaradzhov@perforce.com"
+        },
+        {
+            "name": "Matthew Weier O'Phinney",
+            "email": "mweierophinney@perforce.com"
+        }
+    ],
+    "require": {
+        "php": "^7.2 || ~8.0.0 || ~8.1.0 || ~8.2.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^8.5.33 || ^9.5.11",
+        "laminas/laminas-coding-standard": "~2.1.0"
+    },
+    "autoload": {
+        "classmap": [
+            "src/ZendJobQueue.php"
+        ]
+    },
+    "provide": {
+        "ext-jobqueue": "^2021.1.2"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "platform": {
+            "php": "7.2.99"
+        }
     }
-  ],
-  "require": {
-    "php": ">=5.6.1"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^5.7|^6.0|^9.4",
-    "friendsofphp/php-cs-fixer": "^3.18"
-  },
-  "autoload": {
-    "classmap": [
-      "src/ZendJobQueue.php"
-    ]
-  },
-  "provide": {
-    "ext-jobqueue": "2021.1.2"
-  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,40 +4,40 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1097e207ffaf76e40a6dc83a2680a881",
+    "content-hash": "de6220518fc19f9e499631e36e51df74",
     "packages": [],
     "packages-dev": [
         {
-            "name": "composer/pcre",
-            "version": "3.1.0",
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/composer/pcre.git",
-                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2"
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
-                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.3",
-                "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^5"
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
             },
-            "type": "library",
+            "type": "composer-plugin",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "Composer\\Pcre\\": "src"
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -46,307 +46,41 @@
             ],
             "authors": [
                 {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
                 }
             ],
-            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
             "keywords": [
-                "PCRE",
-                "preg",
-                "regex",
-                "regular expression"
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
             ],
             "support": {
-                "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.1.0"
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
             },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-17T09:50:14+00:00"
-        },
-        {
-            "name": "composer/semver",
-            "version": "3.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/3953f23262f2bff1919fc82183ad9acb13ff62c9",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.4",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Semver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "Semver library that offers utilities, version constraint parsing and validation.",
-            "keywords": [
-                "semantic",
-                "semver",
-                "validation",
-                "versioning"
-            ],
-            "support": {
-                "irc": "irc://irc.freenode.org/composer",
-                "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.3.2"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-04-01T19:23:25+00:00"
-        },
-        {
-            "name": "composer/xdebug-handler",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "ced299686f41dce890debac69273b47ffe98a40c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ced299686f41dce890debac69273b47ffe98a40c",
-                "reference": "ced299686f41dce890debac69273b47ffe98a40c",
-                "shasum": ""
-            },
-            "require": {
-                "composer/pcre": "^1 || ^2 || ^3",
-                "php": "^7.2.5 || ^8.0",
-                "psr/log": "^1 || ^2 || ^3"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.0",
-                "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Composer\\XdebugHandler\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "John Stevenson",
-                    "email": "john-stevenson@blueyonder.co.uk"
-                }
-            ],
-            "description": "Restarts a process without Xdebug.",
-            "keywords": [
-                "Xdebug",
-                "performance"
-            ],
-            "support": {
-                "irc": "irc://irc.freenode.org/composer",
-                "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/3.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-02-25T21:32:43+00:00"
-        },
-        {
-            "name": "doctrine/annotations",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/annotations.git",
-                "reference": "e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f",
-                "reference": "e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/lexer": "^2 || ^3",
-                "ext-tokenizer": "*",
-                "php": "^7.2 || ^8.0",
-                "psr/cache": "^1 || ^2 || ^3"
-            },
-            "require-dev": {
-                "doctrine/cache": "^2.0",
-                "doctrine/coding-standard": "^10",
-                "phpstan/phpstan": "^1.8.0",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "symfony/cache": "^5.4 || ^6",
-                "vimeo/psalm": "^4.10"
-            },
-            "suggest": {
-                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "Docblock Annotations Parser",
-            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
-            "keywords": [
-                "annotations",
-                "docblock",
-                "parser"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/2.0.1"
-            },
-            "time": "2023-02-02T22:02:53+00:00"
-        },
-        {
-            "name": "doctrine/deprecations",
-            "version": "v1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
-                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "phpstan/phpstan": "1.4.10 || 1.10.15",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psalm/plugin-phpunit": "0.18.4",
-                "psr/log": "^1 || ^2 || ^3",
-                "vimeo/psalm": "4.30.0 || 5.12.0"
-            },
-            "suggest": {
-                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
-            "homepage": "https://www.doctrine-project.org/",
-            "support": {
-                "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.1.1"
-            },
-            "time": "2023-06-03T09:27:29+00:00"
+            "time": "2022-02-04T12:51:07+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -419,178 +153,118 @@
             "time": "2022-12-30T00:15:36+00:00"
         },
         {
-            "name": "doctrine/lexer",
+            "name": "laminas/laminas-coding-standard",
             "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/doctrine/lexer.git",
-                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124"
+                "url": "https://github.com/laminas/laminas-coding-standard.git",
+                "reference": "55fb3a9dbd1a34355f50c55474e4c1024054ac9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
-                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/55fb3a9dbd1a34355f50c55474e4c1024054ac9e",
+                "reference": "55fb3a9dbd1a34355f50c55474e4c1024054ac9e",
                 "shasum": ""
             },
             "require": {
-                "doctrine/deprecations": "^1.0",
-                "php": "^7.1 || ^8.0"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.1",
+                "slevomat/coding-standard": "^6.2.0",
+                "squizlabs/php_codesniffer": "^3.5.3",
+                "webimpress/coding-standard": "^1.1.5"
             },
-            "require-dev": {
-                "doctrine/coding-standard": "^9 || ^10",
-                "phpstan/phpstan": "^1.3",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psalm/plugin-phpunit": "^0.18.3",
-                "vimeo/psalm": "^4.11 || ^5.0"
-            },
-            "type": "library",
+            "type": "phpcodesniffer-standard",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Common\\Lexer\\": "src"
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
-            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "description": "Laminas Coding Standard",
+            "homepage": "https://laminas.dev",
             "keywords": [
-                "annotations",
-                "docblock",
-                "lexer",
-                "parser",
-                "php"
+                "Coding Standard",
+                "laminas"
             ],
             "support": {
-                "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/2.1.0"
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-coding-standard/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-coding-standard/issues",
+                "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
+                "source": "https://github.com/laminas/laminas-coding-standard"
             },
             "funding": [
                 {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
-                    "type": "tidelift"
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-14T08:49:07+00:00"
+            "time": "2020-09-08T06:54:43+00:00"
         },
         {
-            "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.18.0",
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "b123395c9fa3a70801f816f13606c0f3a7ada8df"
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "6ede70583e101030bcace4dcddd648f760ddf642"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/b123395c9fa3a70801f816f13606c0f3a7ada8df",
-                "reference": "b123395c9fa3a70801f816f13606c0f3a7ada8df",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6ede70583e101030bcace4dcddd648f760ddf642",
+                "reference": "6ede70583e101030bcace4dcddd648f760ddf642",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^3.3",
-                "composer/xdebug-handler": "^3.0.3",
-                "doctrine/annotations": "^2",
-                "doctrine/lexer": "^2 || ^3",
-                "ext-json": "*",
-                "ext-tokenizer": "*",
-                "php": "^7.4 || ^8.0",
-                "sebastian/diff": "^4.0 || ^5.0",
-                "symfony/console": "^5.4 || ^6.0",
-                "symfony/event-dispatcher": "^5.4 || ^6.0",
-                "symfony/filesystem": "^5.4 || ^6.0",
-                "symfony/finder": "^5.4 || ^6.0",
-                "symfony/options-resolver": "^5.4 || ^6.0",
-                "symfony/polyfill-mbstring": "^1.27",
-                "symfony/polyfill-php80": "^1.27",
-                "symfony/polyfill-php81": "^1.27",
-                "symfony/process": "^5.4 || ^6.0",
-                "symfony/stopwatch": "^5.4 || ^6.0"
+                "php": "^5.6 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "justinrainbow/json-schema": "^5.2",
-                "keradus/cli-executor": "^2.0",
-                "mikey179/vfsstream": "^1.6.11",
-                "php-coveralls/php-coveralls": "^2.5.3",
-                "php-cs-fixer/accessible-object": "^1.1",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
-                "phpspec/prophecy": "^1.16",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5",
-                "phpunitgoodpractices/polyfill": "^1.6",
-                "phpunitgoodpractices/traits": "^1.9.2",
-                "symfony/phpunit-bridge": "^6.2.3",
-                "symfony/yaml": "^5.4 || ^6.0"
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
+                "squizlabs/php_codesniffer": "^3.5"
             },
-            "suggest": {
-                "ext-dom": "For handling output formats in XML",
-                "ext-mbstring": "For handling non-UTF8 characters."
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
             },
-            "bin": [
-                "php-cs-fixer"
-            ],
-            "type": "application",
             "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
                 "psr-4": {
-                    "PhpCsFixer\\": "src/"
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Dariusz Rumiński",
-                    "email": "dariusz.ruminski@gmail.com"
-                }
-            ],
-            "description": "A tool to automatically fix PHP code style",
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
             "keywords": [
-                "Static code analysis",
-                "fixer",
-                "standards",
-                "static analysis"
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
             ],
             "support": {
-                "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.18.0"
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
+                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
+                "source": "https://github.com/laminas/laminas-zendframework-bridge"
             },
             "funding": [
                 {
-                    "url": "https://github.com/keradus",
-                    "type": "github"
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
                 }
             ],
-            "time": "2023-06-18T22:25:45+00:00"
+            "time": "2020-09-14T14:23:00+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -650,62 +324,6 @@
                 }
             ],
             "time": "2023-03-08T13:26:56+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v4.15.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/11e2663a5bc9db5d714eedb4277ee300403b4a9e",
-                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.0"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.5"
-            },
-            "time": "2023-05-19T20:20:00+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -819,45 +437,94 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "9.2.26",
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.4.9",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531",
                 "shasum": ""
             },
             "require": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-pcov": "PHP extension that provides line coverage",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "consistence/coding-standard": "^3.5",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.26",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^6.3",
+                "slevomat/coding-standard": "^4.7.2",
+                "symfony/process": "^4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-master": "0.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+            },
+            "time": "2020-08-03T20:32:43+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "7.0.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "819f92bba8b001d4363065928088de22f25a3a48"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/819f92bba8b001d4363065928088de22f25a3a48",
+                "reference": "819f92bba8b001d4363065928088de22f25a3a48",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.1.3 || ^4.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2.2"
+            },
+            "suggest": {
+                "ext-xdebug": "^2.7.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -885,7 +552,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/7.0.15"
             },
             "funding": [
                 {
@@ -893,32 +560,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T12:58:08+00:00"
+            "time": "2021-07-26T12:20:09+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5",
+                "reference": "42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -945,7 +612,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.5"
             },
             "funding": [
                 {
@@ -953,97 +620,26 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
-        },
-        {
-            "name": "phpunit/php-invoker",
-            "version": "3.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-pcntl": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Invoke callables with a timeout",
-            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
-            "keywords": [
-                "process"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2021-12-02T12:42:26+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "php": ">=5.3.3"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1067,40 +663,34 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -1126,7 +716,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1.3"
             },
             "funding": [
                 {
@@ -1134,54 +724,112 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2020-11-30T08:20:02+00:00"
         },
         {
-            "name": "phpunit/phpunit",
-            "version": "9.6.9",
+            "name": "phpunit/php-token-stream",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778"
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a9aceaf20a682aeacf28d582654a1670d8826778",
-                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9c1da83261628cb24b6a6df371b6e312b3954768",
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
+                "ext-tokenizer": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "abandoned": true,
+            "time": "2021-07-26T12:15:06+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "8.5.33",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "7d1ff0e8c6b35db78ff13e3e05517d7cbf7aa32e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7d1ff0e8c6b35db78ff13e3e05517d7cbf7aa32e",
+                "reference": "7d1ff0e8c6b35db78ff13e3e05517d7cbf7aa32e",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
+                "myclabs/deep-copy": "^1.10.0",
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
-                "phpunit/php-file-iterator": "^3.0.5",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
-                "sebastian/version": "^3.0.2"
+                "php": ">=7.2",
+                "phpunit/php-code-coverage": "^7.0.12",
+                "phpunit/php-file-iterator": "^2.0.4",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.5",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.3",
+                "sebastian/exporter": "^3.1.5",
+                "sebastian/global-state": "^3.0.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
+                "sebastian/version": "^2.0.1"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-soap": "*",
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^2.0.0"
             },
             "bin": [
                 "phpunit"
@@ -1189,13 +837,10 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-master": "8.5-dev"
                 }
             },
             "autoload": {
-                "files": [
-                    "src/Framework/Assert/Functions.php"
-                ],
                 "classmap": [
                     "src/"
                 ]
@@ -1220,8 +865,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.9"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.33"
             },
             "funding": [
                 {
@@ -1237,341 +881,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-11T06:13:56+00:00"
-        },
-        {
-            "name": "psr/cache",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/cache/tree/master"
-            },
-            "time": "2016-08-06T20:24:11+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "1.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
-            },
-            "time": "2021-11-05T16:50:12+00:00"
-        },
-        {
-            "name": "psr/event-dispatcher",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/event-dispatcher.git",
-                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
-                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\EventDispatcher\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Standard interfaces for event handling.",
-            "keywords": [
-                "events",
-                "psr",
-                "psr-14"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/event-dispatcher/issues",
-                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
-            },
-            "time": "2019-01-08T18:20:26+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "1.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
-            },
-            "time": "2021-05-03T11:20:27+00:00"
-        },
-        {
-            "name": "sebastian/cli-parser",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for parsing CLI options",
-            "homepage": "https://github.com/sebastianbergmann/cli-parser",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:08:49+00:00"
-        },
-        {
-            "name": "sebastian/code-unit",
-            "version": "1.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-27T13:04:50+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -1593,7 +928,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.2"
             },
             "funding": [
                 {
@@ -1601,34 +936,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2020-11-30T08:15:22+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "1dc7ceb4a24aede938c7af2a9ed1de09609ca770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1dc7ceb4a24aede938c7af2a9ed1de09609ca770",
+                "reference": "1dc7ceb4a24aede938c7af2a9ed1de09609ca770",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "php": ">=7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1667,7 +1002,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/3.0.5"
             },
             "funding": [
                 {
@@ -1675,90 +1010,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
-        },
-        {
-            "name": "sebastian/complexity",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^4.7",
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for calculating the complexity of PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/complexity",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2022-09-14T12:31:48+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.5",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+                "reference": "6296a0c086dd0117c1b78b059374d7fcbe7545ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/6296a0c086dd0117c1b78b059374d7fcbe7545ae",
+                "reference": "6296a0c086dd0117c1b78b059374d7fcbe7545ae",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1790,7 +1068,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.4"
             },
             "funding": [
                 {
@@ -1798,27 +1076,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T05:35:17+00:00"
+            "time": "2023-05-07T05:30:20+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^7.5"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -1826,7 +1104,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1853,7 +1131,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "source": "https://github.com/sebastianbergmann/environment/tree/4.2.4"
             },
             "funding": [
                 {
@@ -1861,34 +1139,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2020-11-30T07:53:42+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "73a9676f2833b9a7c36968f9d882589cd75511e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/73a9676f2833b9a7c36968f9d882589cd75511e6",
+                "reference": "73a9676f2833b9a7c36968f9d882589cd75511e6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1923,14 +1201,14 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.5"
             },
             "funding": [
                 {
@@ -1938,30 +1216,30 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2022-09-14T06:00:17+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/de036ec91d55d2a9e0db2ba975b512cdb1c23921",
+                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1969,7 +1247,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1994,7 +1272,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/3.0.2"
             },
             "funding": [
                 {
@@ -2002,91 +1280,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
-        },
-        {
-            "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^4.6",
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for counting the lines of code in PHP source code",
-            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2022-02-10T06:55:38+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -2108,7 +1329,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0.4"
             },
             "funding": [
                 {
@@ -2116,32 +1337,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2020-11-30T07:40:27+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -2163,7 +1384,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1.2"
             },
             "funding": [
                 {
@@ -2171,32 +1392,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2020-11-30T07:37:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -2223,10 +1444,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.1"
             },
             "funding": [
                 {
@@ -2234,32 +1455,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
+            "time": "2020-11-30T07:34:24+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "3.0.3",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2281,7 +1499,7 @@
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/2.0.2"
             },
             "funding": [
                 {
@@ -2289,32 +1507,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2020-11-30T07:30:19+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/0150cfbc4495ed2df3872fb31b26781e4e077eb4",
+                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -2337,7 +1555,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/1.1.4"
             },
             "funding": [
                 {
@@ -2345,29 +1563,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2020-11-30T07:25:11+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=5.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -2390,1405 +1608,127 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/master"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
-            "name": "symfony/console",
-            "version": "v5.4.24",
+            "name": "slevomat/coding-standard",
+            "version": "6.4.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8",
-                "reference": "560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/696dcca217d0c9da2c40d02731526c1e25b65346",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php73": "^1.9",
-                "symfony/polyfill-php80": "^1.16",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/string": "^5.1|^6.0"
-            },
-            "conflict": {
-                "psr/log": ">=3",
-                "symfony/dependency-injection": "<4.4",
-                "symfony/dotenv": "<5.1",
-                "symfony/event-dispatcher": "<4.4",
-                "symfony/lock": "<4.4",
-                "symfony/process": "<4.4"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0|2.0"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
+                "squizlabs/php_codesniffer": "^3.5.6"
             },
             "require-dev": {
-                "psr/log": "^1|^2",
-                "symfony/config": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
-                "symfony/lock": "^4.4|^5.0|^6.0",
-                "symfony/process": "^4.4|^5.0|^6.0",
-                "symfony/var-dumper": "^4.4|^5.0|^6.0"
+                "phing/phing": "2.16.3",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
+                "phpstan/phpstan": "0.12.48",
+                "phpstan/phpstan-deprecation-rules": "0.12.5",
+                "phpstan/phpstan-phpunit": "0.12.16",
+                "phpstan/phpstan-strict-rules": "0.12.5",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.4.0"
             },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/lock": "",
-                "symfony/process": ""
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Console\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Eases the creation of beautiful and testable command line interfaces",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "cli",
-                "command-line",
-                "console",
-                "terminal"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.24"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-26T05:13:16+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v2.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
+            "type": "phpcodesniffer-standard",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
+                    "dev-master": "6.x-dev"
                 }
             },
             "autoload": {
-                "files": [
-                    "function.php"
-                ]
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
             },
             "funding": [
                 {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
+                    "url": "https://github.com/kukulich",
                     "type": "github"
                 },
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2020-10-05T12:39:37+00:00"
         },
         {
-            "name": "symfony/event-dispatcher",
-            "version": "v5.4.22",
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "1df20e45d56da29a4b1d8259dd6e950acbf1b13f"
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/1df20e45d56da29a4b1d8259dd6e950acbf1b13f",
-                "reference": "1df20e45d56da29a4b1d8259dd6e950acbf1b13f",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/event-dispatcher-contracts": "^2|^3",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<4.4"
-            },
-            "provide": {
-                "psr/event-dispatcher-implementation": "1.0",
-                "symfony/event-dispatcher-implementation": "2.0"
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "psr/log": "^1|^2|^3",
-                "symfony/config": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/http-foundation": "^4.4|^5.0|^6.0",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/stopwatch": "^4.4|^5.0|^6.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
-            "suggest": {
-                "symfony/dependency-injection": "",
-                "symfony/http-kernel": ""
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.22"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-03-17T11:31:58+00:00"
-        },
-        {
-            "name": "symfony/event-dispatcher-contracts",
-            "version": "v2.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "f98b54df6ad059855739db6fcbc2d36995283fe1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/f98b54df6ad059855739db6fcbc2d36995283fe1",
-                "reference": "f98b54df6ad059855739db6fcbc2d36995283fe1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "psr/event-dispatcher": "^1"
-            },
-            "suggest": {
-                "symfony/event-dispatcher-implementation": ""
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                    "dev-master": "3.x-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Greg Sherwood",
+                    "role": "lead"
                 }
             ],
-            "description": "Generic abstractions related to dispatching event",
-            "homepage": "https://symfony.com",
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
+                "phpcs",
+                "standards",
+                "static analysis"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.5.2"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-02T09:53:40+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v5.4.23",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b2f79d86cd9e7de0fff6d03baa80eaed7a5f38b5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b2f79d86cd9e7de0fff6d03baa80eaed7a5f38b5",
-                "reference": "b2f79d86cd9e7de0fff6d03baa80eaed7a5f38b5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.23"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-03-02T11:38:35+00:00"
-        },
-        {
-            "name": "symfony/finder",
-            "version": "v5.4.21",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "078e9a5e1871fcfe6a5ce421b539344c21afef19"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/078e9a5e1871fcfe6a5ce421b539344c21afef19",
-                "reference": "078e9a5e1871fcfe6a5ce421b539344c21afef19",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Finder\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Finds files and directories via an intuitive fluent interface",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.21"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-02-16T09:33:00+00:00"
-        },
-        {
-            "name": "symfony/options-resolver",
-            "version": "v5.4.21",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9",
-                "reference": "4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php73": "~1.0",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\OptionsResolver\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an improved replacement for the array_replace PHP function",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "config",
-                "configuration",
-                "options"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v5.4.21"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-02-14T08:03:56+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "provide": {
-                "ext-ctype": "*"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's grapheme_* functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "grapheme",
-                "intl",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's Normalizer class and related functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "intl",
-                "normalizer",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "provide": {
-                "ext-mbstring": "*"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php73",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php81",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "707403074c8ea6e2edaf8794b0157a0bfa52157a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/707403074c8ea6e2edaf8794b0157a0bfa52157a",
-                "reference": "707403074c8ea6e2edaf8794b0157a0bfa52157a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php81\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v5.4.24",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "e3c46cc5689c8782944274bb30702106ecbe3b64"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/e3c46cc5689c8782944274bb30702106ecbe3b64",
-                "reference": "e3c46cc5689c8782944274bb30702106ecbe3b64",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.24"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-17T11:26:05+00:00"
-        },
-        {
-            "name": "symfony/service-contracts",
-            "version": "v2.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
-                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "psr/container": "^1.1",
-                "symfony/deprecation-contracts": "^2.1|^3"
-            },
-            "conflict": {
-                "ext-psr": "<1.1|>=2"
-            },
-            "suggest": {
-                "symfony/service-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "2.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Service\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to writing services",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.5.2"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-05-30T19:17:29+00:00"
-        },
-        {
-            "name": "symfony/stopwatch",
-            "version": "v5.4.21",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "f83692cd869a6f2391691d40a01e8acb89e76fee"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/f83692cd869a6f2391691d40a01e8acb89e76fee",
-                "reference": "f83692cd869a6f2391691d40a01e8acb89e76fee",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/service-contracts": "^1|^2|^3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Stopwatch\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides a way to profile code",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.4.21"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-02-14T08:03:56+00:00"
-        },
-        {
-            "name": "symfony/string",
-            "version": "v5.4.22",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/string.git",
-                "reference": "8036a4c76c0dd29e60b6a7cafcacc50cf088ea62"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/8036a4c76c0dd29e60b6a7cafcacc50cf088ea62",
-                "reference": "8036a4c76c0dd29e60b6a7cafcacc50cf088ea62",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.0",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "~1.15"
-            },
-            "conflict": {
-                "symfony/translation-contracts": ">=3.0"
-            },
-            "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/http-client": "^4.4|^5.0|^6.0",
-                "symfony/translation-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0|^6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "Resources/functions.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "grapheme",
-                "i18n",
-                "string",
-                "unicode",
-                "utf-8",
-                "utf8"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.22"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-03-14T06:11:53+00:00"
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -3839,6 +1779,61 @@
                 }
             ],
             "time": "2021-07-28T10:34:58+00:00"
+        },
+        {
+            "name": "webimpress/coding-standard",
+            "version": "1.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "bf3d6d5f231d1c972eac8f41867be296ce33e480"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/bf3d6d5f231d1c972eac8f41867be296ce33e480",
+                "reference": "bf3d6d5f231d1c972eac8f41867be296ce33e480",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "squizlabs/php_codesniffer": "^3.5.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5.20 || ^8.5.3 || ^9.1.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.1.x-dev",
+                "dev-develop": "1.2.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.1.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-27T19:41:48+00:00"
         }
     ],
     "aliases": [],
@@ -3847,8 +1842,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6.1"
+        "php": "^7.2 || ~8.0.0 || ~8.1.0 || ~8.2.0"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.2.99"
+    },
     "plugin-api-version": "2.3.0"
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ruleset
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs.cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="ps"/>
+
+    <!-- Paths to check -->
+    <file>src</file>
+    <!-- <file>test</file> -->
+
+    <!-- Include all rules from Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
+</ruleset>

--- a/src/ZendJobQueue.php
+++ b/src/ZendJobQueue.php
@@ -535,7 +535,6 @@ class ZendJobQueue
      *
      * @param int    $completion The job completion status (OK or FAILED).
      * @param string $message The optional explanation message; ignored internally
-     * @return void
      */
     public static function setCurrentJobStatus(int $completion, string $message = '')
     {
@@ -553,6 +552,18 @@ class ZendJobQueue
      */
     public function removeJob(int $jobId)
     {
+        foreach ($this->jobQueue->getQueues() as $queue) {
+            foreach ($queue->getJobs() as $job) {
+                if (! $job->getId() === $jobId) {
+                    continue;
+                }
+
+                $queue->cancelJob($job);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/ZendJobQueue.php
+++ b/src/ZendJobQueue.php
@@ -32,236 +32,291 @@
 
 use ZendHQ\JobQueue as ZendPhpJQ;
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 class ZendJobQueue
 {
     /**
      * A HTTP type of job with an absolute URL
      */
     public const TYPE_HTTP_RELATIVE = 0;
+
     /**
      * A HTTP type of job with a relative URL
      */
     public const TYPE_HTTP = 1;
+
     /**
      * A SHELL type of job
      */
     public const TYPE_SHELL = 2;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_TYPE_HTTP_RELATIVE = 1;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_TYPE_HTTP = 2;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_TYPE_SHELL = 4;
+
     /**
      * A low priority job
      */
     public const PRIORITY_LOW = 0;
+
     /**
      * A normal priority job
      */
     public const PRIORITY_NORMAL = 1;
+
     /**
      * A high priority job
      */
     public const PRIORITY_HIGH = 2;
+
     /**
      * An urgent priority job
      */
     public const PRIORITY_URGENT = 3;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_PRIORITY_LOW = 1;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_PRIORITY_NORMAL = 2;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_PRIORITY_HIGH = 4;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_PRIORITY_URGENT = 8;
+
     /**
      * The job is waiting to be processed
      */
     public const STATUS_PENDING = 0;
+
     /**
      * The job is waiting for its predecessor's completion
      */
     public const STATUS_WAITING_PREDECESSOR = 1;
+
     /**
      * The job is executing
      */
     public const STATUS_RUNNING = 2;
+
     /**
      * Job execution has been completed successfully
      */
     public const STATUS_COMPLETED = 3;
+
     /**
      * The job was executed and reported its successful completion status
      */
     public const STATUS_OK = 4;
+
     /**
      * The job execution failed
      */
     public const STATUS_FAILED = 5;
+
     /**
      * The job was executed but reported failed completion status
      */
     public const STATUS_LOGICALLY_FAILED = 6;
+
     /**
      * Job execution timeout
      */
     public const STATUS_TIMEOUT = 7;
+
     /**
      * A logically removed job
      */
     public const STATUS_REMOVED = 8;
+
     /**
      * The job is scheduled to be executed at some specific time
      */
     public const STATUS_SCHEDULED = 9;
+
     /**
      * The job execution is suspended
      */
     public const STATUS_SUSPENDED = 10;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_STATUS_PENDING = 1;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_STATUS_WAITING_PREDECESSOR = 2;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_STATUS_RUNNING = 4;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_STATUS_COMPLETED = 8;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_STATUS_OK = 16;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_STATUS_FAILED = 32;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_STATUS_LOGICALLY_FAILED = 64;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_STATUS_TIMEOUT = 128;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_STATUS_REMOVED = 256;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_STATUS_SCHEDULED = 512;
+
     /**
      * (No doc, exported with reflection API)
      */
     public const JOB_STATUS_SUSPENDED = 1024;
+
     /**
      * Disable sorting of result set of getJobsList()
      */
     public const SORT_NONE = 0;
+
     /**
      * Sort result set of getJobsList() by job id
      */
     public const SORT_BY_ID = 1;
+
     /**
      * Sort result set of getJobsList() by job type
      */
     public const SORT_BY_TYPE = 2;
+
     /**
      * Sort result set of getJobsList() by job script name
      */
     public const SORT_BY_SCRIPT = 3;
+
     /**
      * Sort result set of getJobsList() by application name
      */
     public const SORT_BY_APPLICATION = 4;
+
     /**
      * Sort result set of getJobsList() by job name
      */
     public const SORT_BY_NAME = 5;
+
     /**
      * Sort result set of getJobsList() by job priority
      */
     public const SORT_BY_PRIORITY = 6;
+
     /**
      * Sort result set of getJobsList() by job status
      */
     public const SORT_BY_STATUS = 7;
+
     /**
      * Sort result set of getJobsList() by job predecessor
      */
     public const SORT_BY_PREDECESSOR = 8;
+
     /**
      * Sort result set of getJobsList() by job persistence flag
      */
     public const SORT_BY_PERSISTENCE = 9;
+
     /**
      * Sort result set of getJobsList() by job creation time
      */
     public const SORT_BY_CREATION_TIME = 10;
+
     /**
      * Sort result set of getJobsList() by job schedule time
      */
     public const SORT_BY_SCHEDULE_TIME = 11;
+
     /**
      * Sort result set of getJobsList() by job start time
      */
     public const SORT_BY_START_TIME = 12;
+
     /**
      * Sort result set of getJobsList() by job end time
      */
     public const SORT_BY_END_TIME = 13;
+
     /**
      * Sort result set of getJobsList() in direct order
      */
     public const SORT_ASC = 0;
+
     /**
      * Sort result set of getJobsList() in reverse order
      */
     public const SORT_DESC = 1;
+
     /**
      * Constant to report completion status from the jobs using setCurrentJobStatus()
      */
     public const OK = 0;
+
     /**
      * Constant to report completion status from the jobs using setCurrentJobStatus()
      */
     public const FAILED = 1;
 
-    private $binding;
-
-    /** @var ZendPhpJQ\JobQueue */
-    private $jobQueue;
+    private ZendPhpJQ\JobQueue $jobQueue;
 
     /**
      * Creates a ZendJobQueue object connected to a Job Queue daemon.
+     *
+     * @param string $binding This value is accepted for backwards compatibility
+     *     only; internally, it is ignored. Future scope will use this to
+     *     connect to a specific ZendHQ instance once support for that is
+     *     available in the ZendHQ JQ PHP API.
      */
     public function __construct(string $binding = '')
     {
-        $this->binding  = $binding;
         $this->jobQueue = new ZendPhpJQ\JobQueue();
     }
 
@@ -269,20 +324,29 @@ class ZendJobQueue
      * Creates a new URL based job to make the Job Queue Daemon call given $url with given $vars.
      *
      * @param string $url An absolute URL of the script to call.
-     * @param array  $vars An associative array of variables which will be passed to the script. The total data size of this array should not be greater than the size defined in the zend_jobqueue.max_message_size directive.
-     * @param mixed  $options An associative array of additional options. The elements of this array can define job priority, predecessor, persistence, optional name, additional attributes of HTTP request as HTTP headers, etc.
-     *                The following options are supported:
-     *                - "name" - Optional job name
-     *                - "priority" - Job priority (see corresponding constants)
-     *                - "predecessor" - Integer predecessor job id
-     *                - "persistent" - Boolean (keep in history forever)
-     *                - "schedule_time" - Time when job should be executed
-     *                - "schedule" - CRON-like scheduling command
-     *                - "http_headers" - Array of additional HTTP headers
-     *                - "job_timeout" - The timeout for the job
-     *                - "queue_name" - The queue assigned to the job
-     *                - "validate_ssl" - Boolean (validate ssl certificate")
-     * @param bool   $legacyWorker set this parameter to true if the worker is running under real Zend Server.
+     * @param array  $vars An associative array of variables which will be
+     *     passed to the script. The total data size of this array should not be
+     *     greater than the size defined in the zend_jobqueue.max_message_size
+     *     directive.
+     * @param mixed  $options An associative array of additional options. The
+     *     elements of this array can define job priority, predecessor, persistence,
+     *     optional name, additional attributes of HTTP request as HTTP headers,
+     *     etc.
+     *
+     *     The following options are supported:
+     *
+     *     - "name" - Optional job name
+     *     - "priority" - Job priority (see corresponding constants)
+     *     - "predecessor" - Integer predecessor job id
+     *     - "persistent" - Boolean (keep in history forever)
+     *     - "schedule_time" - Time when job should be executed
+     *     - "schedule" - CRON-like scheduling command
+     *     - "http_headers" - Array of additional HTTP headers
+     *     - "job_timeout" - The timeout for the job
+     *     - "queue_name" - The queue assigned to the job
+     *     - "validate_ssl" - Boolean (validate ssl certificate")
+     * @param bool   $legacyWorker set this parameter to true if the worker is
+     *     running under real Zend Server.
      * @return int A job ID which can be used to retrieve the job status.
      */
     public function createHttpJob(string $url, array $vars, $options, bool $legacyWorker = false)
@@ -292,12 +356,15 @@ class ZendJobQueue
             ZendPhpJQ\HTTPJob::HTTP_METHOD_POST,
             $legacyWorker ? ZendPhpJQ\HTTPJob::CONTENT_TYPE_ZEND_SERVER : ZendPhpJQ\HTTPJob::CONTENT_TYPE_URL_ENCODED
         );
+
         $job->addHeader('User-Agent', 'Zend Server Job Queue');
+
         if (isset($options['headers'])) {
             foreach ($options['headers'] as $key => $value) {
                 $job->addHeader($key, $value);
             }
         }
+
         foreach ($vars as $key => $value) {
             $job->addBodyParam($key, $value);
         }
@@ -305,6 +372,7 @@ class ZendJobQueue
         if (isset($options['name'])) {
             $job->setName($options['name']);
         }
+
         $jobSchedule = null;
         if (isset($options['schedule'])) {
             $jobSchedule = new ZendPhpJQ\RecurringSchedule($options['schedule']);
@@ -360,16 +428,19 @@ class ZendJobQueue
     /**
      * Reports job completion status (OK or FAILED) back to the daemon.
      *
-     * @param int completion The job completion status (OK or FAILED).
-     * @param string                                                  $message The optional explanation message.
+     * @param int    $completion The job completion status (OK or FAILED).
+     * @param string $message The optional explanation message.
      */
     public static function setCurrentJobStatus(int $completion, string $message = '')
     {
-        http_response_code($completion == self::OK ? 200 : 500);
+        http_response_code($completion === self::OK ? 200 : 500);
     }
 
     /**
-     * Removes the job from the queue. Makes all dependent jobs fail. If the job is in progress, it will be finished, but dependent jobs will not be started. For non-existing jobs, the function returns false. Finished jobs are removed from the database.
+     * Removes the job from the queue. Makes all dependent jobs fail. If the job
+     * is in progress, it will be finished, but dependent jobs will not be
+     * started. For non-existing jobs, the function returns false. Finished jobs
+     * are removed from the database.
      *
      * @param int $jobId A job ID
      * @return bool The job was removed or not removed.
@@ -382,7 +453,7 @@ class ZendJobQueue
      * Restart a previously executed Job and all its followers.
      *
      * @param int $jobId A job ID
-     * @return bool - If the job was restarted or not restarted.
+     * @return bool If the job was restarted or not restarted.
      */
     public function restartJob(int $jobId)
     {
@@ -407,7 +478,9 @@ class ZendJobQueue
     }
 
     /**
-     * Suspends the Job Queue so it will accept new jobs, but will not start them. The jobs which were executed during the call to this function will be completed.
+     * Suspends the Job Queue so it will accept new jobs, but will not start
+     * them. The jobs which were executed during the call to this function will
+     * be completed.
      */
     public function suspendQueue()
     {
@@ -421,7 +494,9 @@ class ZendJobQueue
     }
 
     /**
-     * Returns internal daemon statistics such as up-time, number of complete jobs, number of failed jobs, number of logically failed jobs, number of waiting jobs, number of currently running jobs, etc.
+     * Returns internal daemon statistics such as up-time, number of complete
+     * jobs, number of failed jobs, number of logically failed jobs, number of
+     * waiting jobs, number of currently running jobs, etc.
      *
      * @return array Associative array.
      */
@@ -432,7 +507,7 @@ class ZendJobQueue
     /**
      * See getStatistics API. Only checks jobs whose status were changed in a given timespan (seconds).
      *
-     * @param int timeSpan The time span in seconds.
+     * @param int $timeSpan The time span in seconds.
      * @return array Associative array.
      */
     public function getStatisticsByTimespan(int $timeSpan)
@@ -466,26 +541,27 @@ class ZendJobQueue
     /**
      * Returns an associative array with properties of the job with the given id from the daemon database
      *
-     * @param int $job_id A job identifier
-     * @return array Array of job details. The following properties are provided (some of them don't have to always be set):
-     *  - "id" : The job identifier
-     *  - "type" : The job type (see self::TYPE_* constants)
-     *  - "status" : The job status (see self::STATUS_* constants)
-     *  - "priority" : The job priority (see self::PRIORITY_* constants)
-     *  - "persistent" : The persistence flag
-     *  - "script" : The URL or SHELL script name
-     *  - "predecessor" : The job predecessor
-     *  - "name" : The job name
-     *  - "vars" : The input variables or arguments
-     *  - "http_headers" : The additional HTTP headers for HTTP jobs
-     *  - "output" : The output of the job
-     *  - "error" : The error output of the job
-     *  - "creation_time" : The time when the job was created
-     *  - "start_time" : The time when the job was started
-     *  - "end_time" : The time when the job was finished
-     *  - "schedule" : The CRON-like schedule command
-     *  - "schedule_time" : The time when the job execution was scheduled
-     *  - "app_id" : The application name
+     * @param int $jobId A job identifier
+     * @return array Array of job details. The following properties are provided
+     *     (some of them don't have to always be set):
+     *     - "id" : The job identifier
+     *     - "type" : The job type (see self::TYPE_* constants)
+     *     - "status" : The job status (see self::STATUS_* constants)
+     *     - "priority" : The job priority (see self::PRIORITY_* constants)
+     *     - "persistent" : The persistence flag
+     *     - "script" : The URL or SHELL script name
+     *     - "predecessor" : The job predecessor
+     *     - "name" : The job name
+     *     - "vars" : The input variables or arguments
+     *     - "http_headers" : The additional HTTP headers for HTTP jobs
+     *     - "output" : The output of the job
+     *     - "error" : The error output of the job
+     *     - "creation_time" : The time when the job was created
+     *     - "start_time" : The time when the job was started
+     *     - "end_time" : The time when the job was finished
+     *     - "schedule" : The CRON-like schedule command
+     *     - "schedule_time" : The time when the job execution was scheduled
+     *     - "app_id" : The application name
      * @since Zend Server 5.0
      */
     public function getJobInfo(int $jobId)
@@ -508,18 +584,18 @@ class ZendJobQueue
             'creation_time' => $job->getCreationTime(),
             'start_time'    => $job->getScheduledTime(),
             'end_time'      => $job->getCompletionTime(),
-//    *  - "vars" : The input variables or arguments
-//    *  - "http_headers" : The additional HTTP headers for HTTP jobs
-//
-//    *  - "error" : The error output of the job
+            // "vars" : The input variables or arguments
+            // "http_headers" : The additional HTTP headers for HTTP jobs
+            // "error" : The error output of the job
             'schedule'      => $job->getSchedule(),
             'schedule_time' => $job->getScheduledTime()->format('Y-m-d H:i:s'),
-//    *  - "app_id" : The application name
+            // "app_id" : The application name
         ];
     }
 
     /**
-     * Returns a list of associative arrays with the properties of the jobs which depend on the job with the given identifier.
+     * Returns a list of associative arrays with the properties of the jobs
+     * which depend on the job with the given identifier.
      */
     public function getDependentJobs()
     {
@@ -529,7 +605,7 @@ class ZendJobQueue
      * Returns a list of associative arrays with properties of jobs which conform to a given query
      *
      * @param array    $filter An associative array with query arguments.
-     *    The array may contain the following keys which restrict the resulting list:
+     *     The array may contain the following keys which restrict the resulting list:
      *     - "app_id" : Query only jobs which belong to the given application
      *     - "name" : Query only jobs with the given name
      *     - "script" : Query only jobs with a script name similar to the given one (SQL LIKE)
@@ -545,7 +621,9 @@ class ZendJobQueue
      *     - "sort_direction" : Sort the order (self::SORT_ASC or self::SORT_DESC)
      *     - "start" : Skip the given number of jobs
      *     - "count" : Retrieve only the given number of jobs (100 by default)
-     * @param null|int $total The output parameter which is set to the total number of jobs conforming to the given query, ignoring "start" and "count" fields
+     * @param null|int $total The output parameter which is set to the total
+     *     number of jobs conforming to the given query, ignoring "start" and
+     *     "count" fields
      * @return array A list of jobs with their details
      */
     public function getJobsList(array $filter = [], $total = null)
@@ -561,7 +639,7 @@ class ZendJobQueue
         }
 
         foreach ($results as $idx => $job) {
-            if (isset($filter['status']) && ($job->getStatus() != $filter['status'])) {
+            if (isset($filter['status']) && ($job->getStatus() !== $filter['status'])) {
                 unset($results[$idx]);
                 continue;
             }
@@ -580,20 +658,22 @@ class ZendJobQueue
     }
 
     /**
-     * Returns an array of all the registered scheduled rules. Each rule is represented by a nested associative array with the following properties:
-     *   "id" - The scheduling rule identifier
-     *   "status" - The rule status (see STATUS_* constants)
-     *   "type" - The rule type (see TYPE_* constants)
-     *   "priority" - The priority of the jobs created by this rule
-     *   "persistent" - The persistence flag of the jobs created by this rule
-     *   "script" - The URL or script to run
-     *   "name" - The name of the jobs created by this rule
-     *   "vars" - The input variables or arguments
-     *   "http_headers" - The additional HTTP headers
-     *   "schedule" - The CRON-like schedule command
-     *   "app_id" - The application name associated with this rule and created jobs
-     *   "last_run" - The last time the rule was run
-     *   "next_run" - The next time the rule will run
+     * Returns an array of all the registered scheduled rules. Each rule is
+     * represented by a nested associative array with the following properties:
+     *
+     * - "id" - The scheduling rule identifier
+     * - "status" - The rule status (see STATUS_* constants)
+     * - "type" - The rule type (see TYPE_* constants)
+     * - "priority" - The priority of the jobs created by this rule
+     * - "persistent" - The persistence flag of the jobs created by this rule
+     * - "script" - The URL or script to run
+     * - "name" - The name of the jobs created by this rule
+     * - "vars" - The input variables or arguments
+     * - "http_headers" - The additional HTTP headers
+     * - "schedule" - The CRON-like schedule command
+     * - "app_id" - The application name associated with this rule and created jobs
+     * - "last_run" - The last time the rule was run
+     * - "next_run" - The next time the rule will run
      *
      * @return array
      */
@@ -602,28 +682,33 @@ class ZendJobQueue
     }
 
     /**
-     * Returns an associative array with the properties of the scheduling rule identified by the given argument. The list of the properties is the same as in getSchedulingRules().
+     * Returns an associative array with the properties of the scheduling rule
+     * identified by the given argument. The list of the properties is the same
+     * as in getSchedulingRules().
      */
     public function getSchedulingRule()
     {
     }
 
     /**
-     * Deletes the scheduling rule identified by the given $rule_id and scheduled jobs created by this rule.
+     * Deletes the scheduling rule identified by the given $rule_id and
+     * scheduled jobs created by this rule.
      */
     public function deleteSchedulingRule()
     {
     }
 
     /**
-     * Suspends the scheduling rule identified by given $rule_id and deletes scheduled jobs created by this rule.
+     * Suspends the scheduling rule identified by given $rule_id and deletes
+     * scheduled jobs created by this rule.
      */
     public function suspendSchedulingRule()
     {
     }
 
     /**
-     * Resumes the scheduling rule identified by given $rule_id and creates a corresponding scheduled job.
+     * Resumes the scheduling rule identified by given $rule_id and creates a
+     * corresponding scheduled job.
      */
     public function resumeSchedulingRule()
     {

--- a/src/ZendJobQueue.php
+++ b/src/ZendJobQueue.php
@@ -32,633 +32,631 @@
 
 use ZendHQ\JobQueue as ZendPhpJQ;
 
-if (! class_exists('ZendJobQueue')) {
-    class ZendJobQueue
+class ZendJobQueue
+{
+    /**
+     * A HTTP type of job with an absolute URL
+     */
+    public const TYPE_HTTP_RELATIVE = 0;
+    /**
+     * A HTTP type of job with a relative URL
+     */
+    public const TYPE_HTTP = 1;
+    /**
+     * A SHELL type of job
+     */
+    public const TYPE_SHELL = 2;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_TYPE_HTTP_RELATIVE = 1;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_TYPE_HTTP = 2;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_TYPE_SHELL = 4;
+    /**
+     * A low priority job
+     */
+    public const PRIORITY_LOW = 0;
+    /**
+     * A normal priority job
+     */
+    public const PRIORITY_NORMAL = 1;
+    /**
+     * A high priority job
+     */
+    public const PRIORITY_HIGH = 2;
+    /**
+     * An urgent priority job
+     */
+    public const PRIORITY_URGENT = 3;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_PRIORITY_LOW = 1;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_PRIORITY_NORMAL = 2;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_PRIORITY_HIGH = 4;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_PRIORITY_URGENT = 8;
+    /**
+     * The job is waiting to be processed
+     */
+    public const STATUS_PENDING = 0;
+    /**
+     * The job is waiting for its predecessor's completion
+     */
+    public const STATUS_WAITING_PREDECESSOR = 1;
+    /**
+     * The job is executing
+     */
+    public const STATUS_RUNNING = 2;
+    /**
+     * Job execution has been completed successfully
+     */
+    public const STATUS_COMPLETED = 3;
+    /**
+     * The job was executed and reported its successful completion status
+     */
+    public const STATUS_OK = 4;
+    /**
+     * The job execution failed
+     */
+    public const STATUS_FAILED = 5;
+    /**
+     * The job was executed but reported failed completion status
+     */
+    public const STATUS_LOGICALLY_FAILED = 6;
+    /**
+     * Job execution timeout
+     */
+    public const STATUS_TIMEOUT = 7;
+    /**
+     * A logically removed job
+     */
+    public const STATUS_REMOVED = 8;
+    /**
+     * The job is scheduled to be executed at some specific time
+     */
+    public const STATUS_SCHEDULED = 9;
+    /**
+     * The job execution is suspended
+     */
+    public const STATUS_SUSPENDED = 10;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_STATUS_PENDING = 1;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_STATUS_WAITING_PREDECESSOR = 2;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_STATUS_RUNNING = 4;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_STATUS_COMPLETED = 8;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_STATUS_OK = 16;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_STATUS_FAILED = 32;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_STATUS_LOGICALLY_FAILED = 64;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_STATUS_TIMEOUT = 128;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_STATUS_REMOVED = 256;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_STATUS_SCHEDULED = 512;
+    /**
+     * (No doc, exported with reflection API)
+     */
+    public const JOB_STATUS_SUSPENDED = 1024;
+    /**
+     * Disable sorting of result set of getJobsList()
+     */
+    public const SORT_NONE = 0;
+    /**
+     * Sort result set of getJobsList() by job id
+     */
+    public const SORT_BY_ID = 1;
+    /**
+     * Sort result set of getJobsList() by job type
+     */
+    public const SORT_BY_TYPE = 2;
+    /**
+     * Sort result set of getJobsList() by job script name
+     */
+    public const SORT_BY_SCRIPT = 3;
+    /**
+     * Sort result set of getJobsList() by application name
+     */
+    public const SORT_BY_APPLICATION = 4;
+    /**
+     * Sort result set of getJobsList() by job name
+     */
+    public const SORT_BY_NAME = 5;
+    /**
+     * Sort result set of getJobsList() by job priority
+     */
+    public const SORT_BY_PRIORITY = 6;
+    /**
+     * Sort result set of getJobsList() by job status
+     */
+    public const SORT_BY_STATUS = 7;
+    /**
+     * Sort result set of getJobsList() by job predecessor
+     */
+    public const SORT_BY_PREDECESSOR = 8;
+    /**
+     * Sort result set of getJobsList() by job persistence flag
+     */
+    public const SORT_BY_PERSISTENCE = 9;
+    /**
+     * Sort result set of getJobsList() by job creation time
+     */
+    public const SORT_BY_CREATION_TIME = 10;
+    /**
+     * Sort result set of getJobsList() by job schedule time
+     */
+    public const SORT_BY_SCHEDULE_TIME = 11;
+    /**
+     * Sort result set of getJobsList() by job start time
+     */
+    public const SORT_BY_START_TIME = 12;
+    /**
+     * Sort result set of getJobsList() by job end time
+     */
+    public const SORT_BY_END_TIME = 13;
+    /**
+     * Sort result set of getJobsList() in direct order
+     */
+    public const SORT_ASC = 0;
+    /**
+     * Sort result set of getJobsList() in reverse order
+     */
+    public const SORT_DESC = 1;
+    /**
+     * Constant to report completion status from the jobs using setCurrentJobStatus()
+     */
+    public const OK = 0;
+    /**
+     * Constant to report completion status from the jobs using setCurrentJobStatus()
+     */
+    public const FAILED = 1;
+
+    private $binding;
+
+    /** @var ZendPhpJQ\JobQueue */
+    private $jobQueue;
+
+    /**
+     * Creates a ZendJobQueue object connected to a Job Queue daemon.
+     */
+    public function __construct(string $binding = '')
     {
-        /**
-         * A HTTP type of job with an absolute URL
-         */
-        public const TYPE_HTTP_RELATIVE = 0;
-        /**
-         * A HTTP type of job with a relative URL
-         */
-        public const TYPE_HTTP = 1;
-        /**
-         * A SHELL type of job
-         */
-        public const TYPE_SHELL = 2;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_TYPE_HTTP_RELATIVE = 1;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_TYPE_HTTP = 2;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_TYPE_SHELL = 4;
-        /**
-         * A low priority job
-         */
-        public const PRIORITY_LOW = 0;
-        /**
-         * A normal priority job
-         */
-        public const PRIORITY_NORMAL = 1;
-        /**
-         * A high priority job
-         */
-        public const PRIORITY_HIGH = 2;
-        /**
-         * An urgent priority job
-         */
-        public const PRIORITY_URGENT = 3;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_PRIORITY_LOW = 1;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_PRIORITY_NORMAL = 2;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_PRIORITY_HIGH = 4;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_PRIORITY_URGENT = 8;
-        /**
-         * The job is waiting to be processed
-         */
-        public const STATUS_PENDING = 0;
-        /**
-         * The job is waiting for its predecessor's completion
-         */
-        public const STATUS_WAITING_PREDECESSOR = 1;
-        /**
-         * The job is executing
-         */
-        public const STATUS_RUNNING = 2;
-        /**
-         * Job execution has been completed successfully
-         */
-        public const STATUS_COMPLETED = 3;
-        /**
-         * The job was executed and reported its successful completion status
-         */
-        public const STATUS_OK = 4;
-        /**
-         * The job execution failed
-         */
-        public const STATUS_FAILED = 5;
-        /**
-         * The job was executed but reported failed completion status
-         */
-        public const STATUS_LOGICALLY_FAILED = 6;
-        /**
-         * Job execution timeout
-         */
-        public const STATUS_TIMEOUT = 7;
-        /**
-         * A logically removed job
-         */
-        public const STATUS_REMOVED = 8;
-        /**
-         * The job is scheduled to be executed at some specific time
-         */
-        public const STATUS_SCHEDULED = 9;
-        /**
-         * The job execution is suspended
-         */
-        public const STATUS_SUSPENDED = 10;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_STATUS_PENDING = 1;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_STATUS_WAITING_PREDECESSOR = 2;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_STATUS_RUNNING = 4;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_STATUS_COMPLETED = 8;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_STATUS_OK = 16;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_STATUS_FAILED = 32;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_STATUS_LOGICALLY_FAILED = 64;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_STATUS_TIMEOUT = 128;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_STATUS_REMOVED = 256;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_STATUS_SCHEDULED = 512;
-        /**
-         * (No doc, exported with reflection API)
-         */
-        public const JOB_STATUS_SUSPENDED = 1024;
-        /**
-         * Disable sorting of result set of getJobsList()
-         */
-        public const SORT_NONE = 0;
-        /**
-         * Sort result set of getJobsList() by job id
-         */
-        public const SORT_BY_ID = 1;
-        /**
-         * Sort result set of getJobsList() by job type
-         */
-        public const SORT_BY_TYPE = 2;
-        /**
-         * Sort result set of getJobsList() by job script name
-         */
-        public const SORT_BY_SCRIPT = 3;
-        /**
-         * Sort result set of getJobsList() by application name
-         */
-        public const SORT_BY_APPLICATION = 4;
-        /**
-         * Sort result set of getJobsList() by job name
-         */
-        public const SORT_BY_NAME = 5;
-        /**
-         * Sort result set of getJobsList() by job priority
-         */
-        public const SORT_BY_PRIORITY = 6;
-        /**
-         * Sort result set of getJobsList() by job status
-         */
-        public const SORT_BY_STATUS = 7;
-        /**
-         * Sort result set of getJobsList() by job predecessor
-         */
-        public const SORT_BY_PREDECESSOR = 8;
-        /**
-         * Sort result set of getJobsList() by job persistence flag
-         */
-        public const SORT_BY_PERSISTENCE = 9;
-        /**
-         * Sort result set of getJobsList() by job creation time
-         */
-        public const SORT_BY_CREATION_TIME = 10;
-        /**
-         * Sort result set of getJobsList() by job schedule time
-         */
-        public const SORT_BY_SCHEDULE_TIME = 11;
-        /**
-         * Sort result set of getJobsList() by job start time
-         */
-        public const SORT_BY_START_TIME = 12;
-        /**
-         * Sort result set of getJobsList() by job end time
-         */
-        public const SORT_BY_END_TIME = 13;
-        /**
-         * Sort result set of getJobsList() in direct order
-         */
-        public const SORT_ASC = 0;
-        /**
-         * Sort result set of getJobsList() in reverse order
-         */
-        public const SORT_DESC = 1;
-        /**
-         * Constant to report completion status from the jobs using setCurrentJobStatus()
-         */
-        public const OK = 0;
-        /**
-         * Constant to report completion status from the jobs using setCurrentJobStatus()
-         */
-        public const FAILED = 1;
+        $this->binding  = $binding;
+        $this->jobQueue = new ZendPhpJQ\JobQueue();
+    }
 
-        private $binding;
-
-        /** @var ZendPhpJQ\JobQueue */
-        private $jobQueue;
-
-        /**
-         * Creates a ZendJobQueue object connected to a Job Queue daemon.
-         */
-        public function __construct(string $binding = '')
-        {
-            $this->binding  = $binding;
-            $this->jobQueue = new ZendPhpJQ\JobQueue();
+    /**
+     * Creates a new URL based job to make the Job Queue Daemon call given $url with given $vars.
+     *
+     * @param string $url An absolute URL of the script to call.
+     * @param array  $vars An associative array of variables which will be passed to the script. The total data size of this array should not be greater than the size defined in the zend_jobqueue.max_message_size directive.
+     * @param mixed  $options An associative array of additional options. The elements of this array can define job priority, predecessor, persistence, optional name, additional attributes of HTTP request as HTTP headers, etc.
+     *                The following options are supported:
+     *                - "name" - Optional job name
+     *                - "priority" - Job priority (see corresponding constants)
+     *                - "predecessor" - Integer predecessor job id
+     *                - "persistent" - Boolean (keep in history forever)
+     *                - "schedule_time" - Time when job should be executed
+     *                - "schedule" - CRON-like scheduling command
+     *                - "http_headers" - Array of additional HTTP headers
+     *                - "job_timeout" - The timeout for the job
+     *                - "queue_name" - The queue assigned to the job
+     *                - "validate_ssl" - Boolean (validate ssl certificate")
+     * @param bool   $legacyWorker set this parameter to true if the worker is running under real Zend Server.
+     * @return int A job ID which can be used to retrieve the job status.
+     */
+    public function createHttpJob(string $url, array $vars, $options, bool $legacyWorker = false)
+    {
+        $job = new ZendPhpJQ\HTTPJob(
+            $url,
+            ZendPhpJQ\HTTPJob::HTTP_METHOD_POST,
+            $legacyWorker ? ZendPhpJQ\HTTPJob::CONTENT_TYPE_ZEND_SERVER : ZendPhpJQ\HTTPJob::CONTENT_TYPE_URL_ENCODED
+        );
+        $job->addHeader('User-Agent', 'Zend Server Job Queue');
+        if (isset($options['headers'])) {
+            foreach ($options['headers'] as $key => $value) {
+                $job->addHeader($key, $value);
+            }
+        }
+        foreach ($vars as $key => $value) {
+            $job->addBodyParam($key, $value);
         }
 
-        /**
-         * Creates a new URL based job to make the Job Queue Daemon call given $url with given $vars.
-         *
-         * @param string $url An absolute URL of the script to call.
-         * @param array  $vars An associative array of variables which will be passed to the script. The total data size of this array should not be greater than the size defined in the zend_jobqueue.max_message_size directive.
-         * @param mixed  $options An associative array of additional options. The elements of this array can define job priority, predecessor, persistence, optional name, additional attributes of HTTP request as HTTP headers, etc.
-         *                The following options are supported:
-         *                - "name" - Optional job name
-         *                - "priority" - Job priority (see corresponding constants)
-         *                - "predecessor" - Integer predecessor job id
-         *                - "persistent" - Boolean (keep in history forever)
-         *                - "schedule_time" - Time when job should be executed
-         *                - "schedule" - CRON-like scheduling command
-         *                - "http_headers" - Array of additional HTTP headers
-         *                - "job_timeout" - The timeout for the job
-         *                - "queue_name" - The queue assigned to the job
-         *                - "validate_ssl" - Boolean (validate ssl certificate")
-         * @param bool   $legacyWorker set this parameter to true if the worker is running under real Zend Server.
-         * @return int A job ID which can be used to retrieve the job status.
-         */
-        public function createHttpJob(string $url, array $vars, $options, bool $legacyWorker = false)
-        {
-            $job = new ZendPhpJQ\HTTPJob(
-                $url,
-                ZendPhpJQ\HTTPJob::HTTP_METHOD_POST,
-                $legacyWorker ? ZendPhpJQ\HTTPJob::CONTENT_TYPE_ZEND_SERVER : ZendPhpJQ\HTTPJob::CONTENT_TYPE_URL_ENCODED
+        if (isset($options['name'])) {
+            $job->setName($options['name']);
+        }
+        $jobSchedule = null;
+        if (isset($options['schedule'])) {
+            $jobSchedule = new ZendPhpJQ\RecurringSchedule($options['schedule']);
+        } elseif (isset($options['schedule_time'])) {
+            $jobSchedule = new ZendPhpJQ\ScheduledTime(
+                DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $options['schedule_time'])
             );
-            $job->addHeader('User-Agent', 'Zend Server Job Queue');
-            if (isset($options['headers'])) {
-                foreach ($options['headers'] as $key => $value) {
-                    $job->addHeader($key, $value);
-                }
-            }
-            foreach ($vars as $key => $value) {
-                $job->addBodyParam($key, $value);
-            }
-
-            if (isset($options['name'])) {
-                $job->setName($options['name']);
-            }
-            $jobSchedule = null;
-            if (isset($options['schedule'])) {
-                $jobSchedule = new ZendPhpJQ\RecurringSchedule($options['schedule']);
-            } elseif (isset($options['schedule_time'])) {
-                $jobSchedule = new ZendPhpJQ\ScheduledTime(
-                    DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $options['schedule_time'])
-                );
-            }
-
-            // warning: the following options are not supported: `queue_name` and `predecessor`
-            $jobOptions = new ZendPhpJQ\JobOptions(
-                $options['priority'] ?? null,
-                $options['job_timeout'] ?? null,
-                null,
-                null,
-                $options['persistent'] ?? ZendPhpJQ\JobOptions::PERSIST_OUTPUT_YES,
-                $options['validate_ssl'] ?? null
-            );
-
-            return $this->jobQueue->getDefaultQueue()->scheduleJob($job, $jobSchedule, $jobOptions)->getId();
         }
 
-        /**
-         * Retrieves status of previously created job identified by its ID.
-         *
-         * @param int $jobId A job ID.
-         * @return array The array contains status, completion status and output of the job.
-         */
-        public function getJobStatus(int $jobId)
-        {
-            $job = $this->getJobById($jobId);
-            if ($job === null) {
-                return [];
-            }
+        // warning: the following options are not supported: `queue_name` and `predecessor`
+        $jobOptions = new ZendPhpJQ\JobOptions(
+            $options['priority'] ?? null,
+            $options['job_timeout'] ?? null,
+            null,
+            null,
+            $options['persistent'] ?? ZendPhpJQ\JobOptions::PERSIST_OUTPUT_YES,
+            $options['validate_ssl'] ?? null
+        );
 
-            // TODO: remap job status
-            return [
-                'status' => $job->getStatus(), // TODO: remap job status
-                'output' => $job->getOutput(),
-            ];
+        return $this->jobQueue->getDefaultQueue()->scheduleJob($job, $jobSchedule, $jobOptions)->getId();
+    }
+
+    /**
+     * Retrieves status of previously created job identified by its ID.
+     *
+     * @param int $jobId A job ID.
+     * @return array The array contains status, completion status and output of the job.
+     */
+    public function getJobStatus(int $jobId)
+    {
+        $job = $this->getJobById($jobId);
+        if ($job === null) {
+            return [];
         }
 
-        /**
-         * Decodes an array of input variables passed to the HTTP job.
-         *
-         * @return array The job variables.
-         */
-        public static function getCurrentJobParams()
-        {
-            return $_POST;
+        // TODO: remap job status
+        return [
+            'status' => $job->getStatus(), // TODO: remap job status
+            'output' => $job->getOutput(),
+        ];
+    }
+
+    /**
+     * Decodes an array of input variables passed to the HTTP job.
+     *
+     * @return array The job variables.
+     */
+    public static function getCurrentJobParams()
+    {
+        return $_POST;
+    }
+
+    /**
+     * Reports job completion status (OK or FAILED) back to the daemon.
+     *
+     * @param int completion The job completion status (OK or FAILED).
+     * @param string                                                  $message The optional explanation message.
+     */
+    public static function setCurrentJobStatus(int $completion, string $message = '')
+    {
+        http_response_code($completion == self::OK ? 200 : 500);
+    }
+
+    /**
+     * Removes the job from the queue. Makes all dependent jobs fail. If the job is in progress, it will be finished, but dependent jobs will not be started. For non-existing jobs, the function returns false. Finished jobs are removed from the database.
+     *
+     * @param int $jobId A job ID
+     * @return bool The job was removed or not removed.
+     */
+    public function removeJob(int $jobId)
+    {
+    }
+
+    /**
+     * Restart a previously executed Job and all its followers.
+     *
+     * @param int $jobId A job ID
+     * @return bool - If the job was restarted or not restarted.
+     */
+    public function restartJob(int $jobId)
+    {
+    }
+
+    /**
+     * Checks if the Job Queue is suspended and returns true or false.
+     *
+     * @return bool A Job Queue status.
+     */
+    public function isSuspended()
+    {
+    }
+
+    /**
+     * Checks if the Job Queue Daemon is running.
+     *
+     * @return bool Return true if the Job Queue Deamon is running, otherwise it returns false.
+     */
+    public static function isJobQueueDaemonRunning()
+    {
+    }
+
+    /**
+     * Suspends the Job Queue so it will accept new jobs, but will not start them. The jobs which were executed during the call to this function will be completed.
+     */
+    public function suspendQueue()
+    {
+    }
+
+    /**
+     * Resumes the Job Queue so it will schedule and start queued jobs.
+     */
+    public function resumeQueue()
+    {
+    }
+
+    /**
+     * Returns internal daemon statistics such as up-time, number of complete jobs, number of failed jobs, number of logically failed jobs, number of waiting jobs, number of currently running jobs, etc.
+     *
+     * @return array Associative array.
+     */
+    public function getStatistics()
+    {
+    }
+
+    /**
+     * See getStatistics API. Only checks jobs whose status were changed in a given timespan (seconds).
+     *
+     * @param int timeSpan The time span in seconds.
+     * @return array Associative array.
+     */
+    public function getStatisticsByTimespan(int $timeSpan)
+    {
+    }
+
+    /**
+     * Returns the current value of the configuration option of the Job Queue Daemon.
+     */
+    public function getConfig()
+    {
+    }
+
+    /**
+     * Returns the list of available queues.
+     *
+     * @return array
+     */
+    public function getQueues()
+    {
+        return $this->jobQueue->getQueues();
+    }
+
+    /**
+     * Re-reads the configuration file of the Job Queue Daemon, and reloads all directives that are reloadable.
+     */
+    public function reloadConfig()
+    {
+    }
+
+    /**
+     * Returns an associative array with properties of the job with the given id from the daemon database
+     *
+     * @param int $job_id A job identifier
+     * @return array Array of job details. The following properties are provided (some of them don't have to always be set):
+     *  - "id" : The job identifier
+     *  - "type" : The job type (see self::TYPE_* constants)
+     *  - "status" : The job status (see self::STATUS_* constants)
+     *  - "priority" : The job priority (see self::PRIORITY_* constants)
+     *  - "persistent" : The persistence flag
+     *  - "script" : The URL or SHELL script name
+     *  - "predecessor" : The job predecessor
+     *  - "name" : The job name
+     *  - "vars" : The input variables or arguments
+     *  - "http_headers" : The additional HTTP headers for HTTP jobs
+     *  - "output" : The output of the job
+     *  - "error" : The error output of the job
+     *  - "creation_time" : The time when the job was created
+     *  - "start_time" : The time when the job was started
+     *  - "end_time" : The time when the job was finished
+     *  - "schedule" : The CRON-like schedule command
+     *  - "schedule_time" : The time when the job execution was scheduled
+     *  - "app_id" : The application name
+     * @since Zend Server 5.0
+     */
+    public function getJobInfo(int $jobId)
+    {
+        $job = $this->getJobById($jobId);
+        if ($job === null) {
+            return [];
         }
 
-        /**
-         * Reports job completion status (OK or FAILED) back to the daemon.
-         *
-         * @param int completion The job completion status (OK or FAILED).
-         * @param string                                                  $message The optional explanation message.
-         */
-        public static function setCurrentJobStatus(int $completion, string $message = '')
-        {
-            http_response_code($completion == self::OK ? 200 : 500);
-        }
-
-        /**
-         * Removes the job from the queue. Makes all dependent jobs fail. If the job is in progress, it will be finished, but dependent jobs will not be started. For non-existing jobs, the function returns false. Finished jobs are removed from the database.
-         *
-         * @param int $jobId A job ID
-         * @return bool The job was removed or not removed.
-         */
-        public function removeJob(int $jobId)
-        {
-        }
-
-        /**
-         * Restart a previously executed Job and all its followers.
-         *
-         * @param int $jobId A job ID
-         * @return bool - If the job was restarted or not restarted.
-         */
-        public function restartJob(int $jobId)
-        {
-        }
-
-        /**
-         * Checks if the Job Queue is suspended and returns true or false.
-         *
-         * @return bool A Job Queue status.
-         */
-        public function isSuspended()
-        {
-        }
-
-        /**
-         * Checks if the Job Queue Daemon is running.
-         *
-         * @return bool Return true if the Job Queue Deamon is running, otherwise it returns false.
-         */
-        public static function isJobQueueDaemonRunning()
-        {
-        }
-
-        /**
-         * Suspends the Job Queue so it will accept new jobs, but will not start them. The jobs which were executed during the call to this function will be completed.
-         */
-        public function suspendQueue()
-        {
-        }
-
-        /**
-         * Resumes the Job Queue so it will schedule and start queued jobs.
-         */
-        public function resumeQueue()
-        {
-        }
-
-        /**
-         * Returns internal daemon statistics such as up-time, number of complete jobs, number of failed jobs, number of logically failed jobs, number of waiting jobs, number of currently running jobs, etc.
-         *
-         * @return array Associative array.
-         */
-        public function getStatistics()
-        {
-        }
-
-        /**
-         * See getStatistics API. Only checks jobs whose status were changed in a given timespan (seconds).
-         *
-         * @param int timeSpan The time span in seconds.
-         * @return array Associative array.
-         */
-        public function getStatisticsByTimespan(int $timeSpan)
-        {
-        }
-
-        /**
-         * Returns the current value of the configuration option of the Job Queue Daemon.
-         */
-        public function getConfig()
-        {
-        }
-
-        /**
-         * Returns the list of available queues.
-         *
-         * @return array
-         */
-        public function getQueues()
-        {
-            return $this->jobQueue->getQueues();
-        }
-
-        /**
-         * Re-reads the configuration file of the Job Queue Daemon, and reloads all directives that are reloadable.
-         */
-        public function reloadConfig()
-        {
-        }
-
-        /**
-         * Returns an associative array with properties of the job with the given id from the daemon database
-         *
-         * @param int $job_id A job identifier
-         * @return array Array of job details. The following properties are provided (some of them don't have to always be set):
-         *  - "id" : The job identifier
-         *  - "type" : The job type (see self::TYPE_* constants)
-         *  - "status" : The job status (see self::STATUS_* constants)
-         *  - "priority" : The job priority (see self::PRIORITY_* constants)
-         *  - "persistent" : The persistence flag
-         *  - "script" : The URL or SHELL script name
-         *  - "predecessor" : The job predecessor
-         *  - "name" : The job name
-         *  - "vars" : The input variables or arguments
-         *  - "http_headers" : The additional HTTP headers for HTTP jobs
-         *  - "output" : The output of the job
-         *  - "error" : The error output of the job
-         *  - "creation_time" : The time when the job was created
-         *  - "start_time" : The time when the job was started
-         *  - "end_time" : The time when the job was finished
-         *  - "schedule" : The CRON-like schedule command
-         *  - "schedule_time" : The time when the job execution was scheduled
-         *  - "app_id" : The application name
-         * @since Zend Server 5.0
-         */
-        public function getJobInfo(int $jobId)
-        {
-            $job = $this->getJobById($jobId);
-            if ($job === null) {
-                return [];
-            }
-
-            return [
-                'id'         => $job->getId(),
-                'name'       => $job->getJobDefinition()->getName(),
-                'type'       => '', // The job type (see self::TYPE_* constants)
-                'status'     => $job->getStatus(),
-                'priority'   => $job->getJobOptions()->getPriority(),
-                'persistent' => $job->getJobOptions()->getPersistOutput(),
-                // "script" : The URL or SHELL script name
-                // "predecessor" : The job predecessor
-                'output'        => $job->getOutput(),
-                'creation_time' => $job->getCreationTime(),
-                'start_time'    => $job->getScheduledTime(),
-                'end_time'      => $job->getCompletionTime(),
+        return [
+            'id'         => $job->getId(),
+            'name'       => $job->getJobDefinition()->getName(),
+            'type'       => '', // The job type (see self::TYPE_* constants)
+            'status'     => $job->getStatus(),
+            'priority'   => $job->getJobOptions()->getPriority(),
+            'persistent' => $job->getJobOptions()->getPersistOutput(),
+            // "script" : The URL or SHELL script name
+            // "predecessor" : The job predecessor
+            'output'        => $job->getOutput(),
+            'creation_time' => $job->getCreationTime(),
+            'start_time'    => $job->getScheduledTime(),
+            'end_time'      => $job->getCompletionTime(),
 //    *  - "vars" : The input variables or arguments
 //    *  - "http_headers" : The additional HTTP headers for HTTP jobs
 //
 //    *  - "error" : The error output of the job
-                'schedule'      => $job->getSchedule(),
-                'schedule_time' => $job->getScheduledTime()->format('Y-m-d H:i:s'),
+            'schedule'      => $job->getSchedule(),
+            'schedule_time' => $job->getScheduledTime()->format('Y-m-d H:i:s'),
 //    *  - "app_id" : The application name
-            ];
-        }
-
-        /**
-         * Returns a list of associative arrays with the properties of the jobs which depend on the job with the given identifier.
-         */
-        public function getDependentJobs()
-        {
-        }
-
-        /**
-         * Returns a list of associative arrays with properties of jobs which conform to a given query
-         *
-         * @param array    $filter An associative array with query arguments.
-         *    The array may contain the following keys which restrict the resulting list:
-         *     - "app_id" : Query only jobs which belong to the given application
-         *     - "name" : Query only jobs with the given name
-         *     - "script" : Query only jobs with a script name similar to the given one (SQL LIKE)
-         *     - "type" : Query only jobs of the given types (bitset)
-         *     - "priority" : Query only jobs with the given priorities (bitset)
-         *     - "status" : Query only jobs with the given statuses (bitset)
-         *     - "rule_id" : Query only jobs produced by the given scheduling rule
-         *     - "scheduled_before" : Query only jobs scheduled before the given date
-         *     - "scheduled_after" : Query only jobs scheduled after the given date
-         *     - "executed_before" : Query only jobs executed before the given date
-         *     - "executed_after" : Query only jobs executed after the given date
-         *     - "sort_by" : Sort by the given field (see self::SORT_BY_* constants)
-         *     - "sort_direction" : Sort the order (self::SORT_ASC or self::SORT_DESC)
-         *     - "start" : Skip the given number of jobs
-         *     - "count" : Retrieve only the given number of jobs (100 by default)
-         * @param null|int $total The output parameter which is set to the total number of jobs conforming to the given query, ignoring "start" and "count" fields
-         * @return array A list of jobs with their details
-         */
-        public function getJobsList(array $filter = [], $total = null)
-        {
-            $results = [];
-            foreach ($this->getQueues() as $queue) {
-                if (isset($filter['name'])) {
-                    $results = array_merge($results, $queue->getJobsByName($filter['name']));
-                    continue;
-                }
-
-                $results[] = $queue->getJobs();
-            }
-
-            foreach ($results as $idx => $job) {
-                if (isset($filter['status']) && ($job->getStatus() != $filter['status'])) {
-                    unset($results[$idx]);
-                    continue;
-                }
-
-                // TODO: add other filtering parameters...
-            }
-
-            return $results;
-        }
-
-        /**
-         * Returns an array of application names known by the daemon.
-         */
-        public function getApplications()
-        {
-        }
-
-        /**
-         * Returns an array of all the registered scheduled rules. Each rule is represented by a nested associative array with the following properties:
-         *   "id" - The scheduling rule identifier
-         *   "status" - The rule status (see STATUS_* constants)
-         *   "type" - The rule type (see TYPE_* constants)
-         *   "priority" - The priority of the jobs created by this rule
-         *   "persistent" - The persistence flag of the jobs created by this rule
-         *   "script" - The URL or script to run
-         *   "name" - The name of the jobs created by this rule
-         *   "vars" - The input variables or arguments
-         *   "http_headers" - The additional HTTP headers
-         *   "schedule" - The CRON-like schedule command
-         *   "app_id" - The application name associated with this rule and created jobs
-         *   "last_run" - The last time the rule was run
-         *   "next_run" - The next time the rule will run
-         *
-         * @return array
-         */
-        public function getSchedulingRules()
-        {
-        }
-
-        /**
-         * Returns an associative array with the properties of the scheduling rule identified by the given argument. The list of the properties is the same as in getSchedulingRules().
-         */
-        public function getSchedulingRule()
-        {
-        }
-
-        /**
-         * Deletes the scheduling rule identified by the given $rule_id and scheduled jobs created by this rule.
-         */
-        public function deleteSchedulingRule()
-        {
-        }
-
-        /**
-         * Suspends the scheduling rule identified by given $rule_id and deletes scheduled jobs created by this rule.
-         */
-        public function suspendSchedulingRule()
-        {
-        }
-
-        /**
-         * Resumes the scheduling rule identified by given $rule_id and creates a corresponding scheduled job.
-         */
-        public function resumeSchedulingRule()
-        {
-        }
-
-        /**
-         * Updates and reschedules the existing scheduling rule.
-         */
-        public function updateSchedulingRule()
-        {
-        }
-
-        /**
-         * Returns the current job ID. Returns NULL if not called within a job context.
-         */
-        public static function getCurrentJobId()
-        {
-        }
-
-        /**
-         * Get Job By Id
-         *
-         * @return ZendPhpJQ\Job|null
-         */
-        private function getJobById(int $jobId)
-        {
-            foreach ($this->getQueues() as $queue) {
-                try {
-                    return $queue->getJob($jobId);
-                } catch (ZendPhpJQ\InvalidArgument $ex) {
-                }
-            }
-
-            return null;
-        }
+        ];
     }
-} // if class exists
+
+    /**
+     * Returns a list of associative arrays with the properties of the jobs which depend on the job with the given identifier.
+     */
+    public function getDependentJobs()
+    {
+    }
+
+    /**
+     * Returns a list of associative arrays with properties of jobs which conform to a given query
+     *
+     * @param array    $filter An associative array with query arguments.
+     *    The array may contain the following keys which restrict the resulting list:
+     *     - "app_id" : Query only jobs which belong to the given application
+     *     - "name" : Query only jobs with the given name
+     *     - "script" : Query only jobs with a script name similar to the given one (SQL LIKE)
+     *     - "type" : Query only jobs of the given types (bitset)
+     *     - "priority" : Query only jobs with the given priorities (bitset)
+     *     - "status" : Query only jobs with the given statuses (bitset)
+     *     - "rule_id" : Query only jobs produced by the given scheduling rule
+     *     - "scheduled_before" : Query only jobs scheduled before the given date
+     *     - "scheduled_after" : Query only jobs scheduled after the given date
+     *     - "executed_before" : Query only jobs executed before the given date
+     *     - "executed_after" : Query only jobs executed after the given date
+     *     - "sort_by" : Sort by the given field (see self::SORT_BY_* constants)
+     *     - "sort_direction" : Sort the order (self::SORT_ASC or self::SORT_DESC)
+     *     - "start" : Skip the given number of jobs
+     *     - "count" : Retrieve only the given number of jobs (100 by default)
+     * @param null|int $total The output parameter which is set to the total number of jobs conforming to the given query, ignoring "start" and "count" fields
+     * @return array A list of jobs with their details
+     */
+    public function getJobsList(array $filter = [], $total = null)
+    {
+        $results = [];
+        foreach ($this->getQueues() as $queue) {
+            if (isset($filter['name'])) {
+                $results = array_merge($results, $queue->getJobsByName($filter['name']));
+                continue;
+            }
+
+            $results[] = $queue->getJobs();
+        }
+
+        foreach ($results as $idx => $job) {
+            if (isset($filter['status']) && ($job->getStatus() != $filter['status'])) {
+                unset($results[$idx]);
+                continue;
+            }
+
+            // TODO: add other filtering parameters...
+        }
+
+        return $results;
+    }
+
+    /**
+     * Returns an array of application names known by the daemon.
+     */
+    public function getApplications()
+    {
+    }
+
+    /**
+     * Returns an array of all the registered scheduled rules. Each rule is represented by a nested associative array with the following properties:
+     *   "id" - The scheduling rule identifier
+     *   "status" - The rule status (see STATUS_* constants)
+     *   "type" - The rule type (see TYPE_* constants)
+     *   "priority" - The priority of the jobs created by this rule
+     *   "persistent" - The persistence flag of the jobs created by this rule
+     *   "script" - The URL or script to run
+     *   "name" - The name of the jobs created by this rule
+     *   "vars" - The input variables or arguments
+     *   "http_headers" - The additional HTTP headers
+     *   "schedule" - The CRON-like schedule command
+     *   "app_id" - The application name associated with this rule and created jobs
+     *   "last_run" - The last time the rule was run
+     *   "next_run" - The next time the rule will run
+     *
+     * @return array
+     */
+    public function getSchedulingRules()
+    {
+    }
+
+    /**
+     * Returns an associative array with the properties of the scheduling rule identified by the given argument. The list of the properties is the same as in getSchedulingRules().
+     */
+    public function getSchedulingRule()
+    {
+    }
+
+    /**
+     * Deletes the scheduling rule identified by the given $rule_id and scheduled jobs created by this rule.
+     */
+    public function deleteSchedulingRule()
+    {
+    }
+
+    /**
+     * Suspends the scheduling rule identified by given $rule_id and deletes scheduled jobs created by this rule.
+     */
+    public function suspendSchedulingRule()
+    {
+    }
+
+    /**
+     * Resumes the scheduling rule identified by given $rule_id and creates a corresponding scheduled job.
+     */
+    public function resumeSchedulingRule()
+    {
+    }
+
+    /**
+     * Updates and reschedules the existing scheduling rule.
+     */
+    public function updateSchedulingRule()
+    {
+    }
+
+    /**
+     * Returns the current job ID. Returns NULL if not called within a job context.
+     */
+    public static function getCurrentJobId()
+    {
+    }
+
+    /**
+     * Get Job By Id
+     *
+     * @return ZendPhpJQ\Job|null
+     */
+    private function getJobById(int $jobId)
+    {
+        foreach ($this->getQueues() as $queue) {
+            try {
+                return $queue->getJob($jobId);
+            } catch (ZendPhpJQ\InvalidArgument $ex) {
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ZendJobQueue.php
+++ b/src/ZendJobQueue.php
@@ -35,35 +35,49 @@ use ZendHQ\JobQueue as ZendPhpJQ;
 // phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 class ZendJobQueue
 {
+    // Job types
+
     /**
-     * A HTTP type of job with an absolute URL
+     * An HTTP job with a relative URL
      */
     public const TYPE_HTTP_RELATIVE = 0;
 
     /**
-     * A HTTP type of job with a relative URL
+     * An HTTP job with an absolute URL
      */
     public const TYPE_HTTP = 1;
 
     /**
-     * A SHELL type of job
+     * A PHP-backed CLI job
      */
-    public const TYPE_SHELL = 2;
+    public const TYPE_CLI_PHP = 2;
 
     /**
-     * (No doc, exported with reflection API)
+     * A CLI job
+     */
+    public const TYPE_CLI = 3;
+
+    /**
+     * A shell job
+     */
+    public const TYPE_SHELL = 3;
+
+    /**
+     * An HTTP job with a relative URL
      */
     public const JOB_TYPE_HTTP_RELATIVE = 1;
 
     /**
-     * (No doc, exported with reflection API)
+     * An HTTP job with an absolute URL
      */
     public const JOB_TYPE_HTTP = 2;
 
     /**
-     * (No doc, exported with reflection API)
+     * A shell-based job
      */
-    public const JOB_TYPE_SHELL = 4;
+    public const JOB_TYPE_SHELL = 8;
+
+    // Job priorities
 
     /**
      * A low priority job
@@ -86,24 +100,111 @@ class ZendJobQueue
     public const PRIORITY_URGENT = 3;
 
     /**
-     * (No doc, exported with reflection API)
+     * A low priority job
      */
     public const JOB_PRIORITY_LOW = 1;
 
     /**
-     * (No doc, exported with reflection API)
+     * A normal priority job
      */
     public const JOB_PRIORITY_NORMAL = 2;
 
     /**
-     * (No doc, exported with reflection API)
+     * A high priority job
      */
     public const JOB_PRIORITY_HIGH = 4;
 
     /**
-     * (No doc, exported with reflection API)
+     * An urgent priority job
      */
     public const JOB_PRIORITY_URGENT = 8;
+
+    // Job statuses
+
+    /**
+     * The job is waiting to be processed
+     */
+    public const JOB_STATUS_PENDING = 1;
+
+    /**
+     * The job is waiting for its predecessor's completion
+     */
+    public const JOB_STATUS_WAITING_PREDECESSOR = 2;
+
+    /**
+     * The job is executing
+     */
+    public const JOB_STATUS_RUNNING = 4;
+
+    /**
+     * Job execution has been completed successfully
+     */
+    public const JOB_STATUS_COMPLETED = 8;
+
+    /**
+     * The job was executed and reported its successful completion status
+     */
+    public const JOB_STATUS_OK = 16;
+
+    /**
+     * The job execution failed
+     */
+    public const JOB_STATUS_FAILED = 32;
+
+    /**
+     * The job was executed but reported failed completion status
+     */
+    public const JOB_STATUS_LOGICALLY_FAILED = 64;
+
+    /**
+     * Job execution timeout
+     */
+    public const JOB_STATUS_TIMEOUT = 128;
+
+    /**
+     * A logically removed job
+     */
+    public const JOB_STATUS_REMOVED = 256;
+
+    /**
+     * The job is scheduled to be executed at some specific time
+     */
+    public const JOB_STATUS_SCHEDULED = 512;
+
+    /**
+     * The job execution is suspended
+     */
+    public const JOB_STATUS_SUSPENDED = 1024;
+
+    /**
+     * The job execution failed on the backend
+     */
+    public const JOB_STATUS_FAILED_BACKEND = 2048;
+
+    /**
+     * The job execution failed due to the target URL being inaccessible
+     */
+    public const JOB_STATUS_FAILED_URL = 4096;
+
+    /**
+     * The job execution failed due to the runtime not matching
+     */
+    public const JOB_STATUS_FAILED_RUNTIME = 8192;
+
+    /**
+     * The job execution failed to start
+     */
+    public const JOB_STATUS_FAILED_START = 16384;
+
+    /**
+     * The job execution failed due to the predecessor job failing
+     */
+    public const JOB_STATUS_FAILED_PREDECESSOR = 32768;
+
+    /**
+     * The job execution failed because it was aborted
+     */
+    public const JOB_STATUS_FAILED_ABORTED = 65536;
 
     /**
      * The job is waiting to be processed
@@ -161,59 +262,41 @@ class ZendJobQueue
     public const STATUS_SUSPENDED = 10;
 
     /**
-     * (No doc, exported with reflection API)
+     * The job execution failed on the backend
      */
-    public const JOB_STATUS_PENDING = 1;
+    public const STATUS_FAILED_BACKEND = 11;
 
     /**
-     * (No doc, exported with reflection API)
+     * The job execution failed due to the target URL being inaccessible
      */
-    public const JOB_STATUS_WAITING_PREDECESSOR = 2;
+    public const STATUS_FAILED_URL = 12;
 
     /**
-     * (No doc, exported with reflection API)
+     * The job execution failed due to the runtime not matching
      */
-    public const JOB_STATUS_RUNNING = 4;
+    public const STATUS_FAILED_RUNTIME = 13;
 
     /**
-     * (No doc, exported with reflection API)
+     * The job execution failed to start
      */
-    public const JOB_STATUS_COMPLETED = 8;
+    public const STATUS_FAILED_START = 14;
 
     /**
-     * (No doc, exported with reflection API)
+     * The job execution failed due to the predecessor job failing
      */
-    public const JOB_STATUS_OK = 16;
+    public const STATUS_FAILED_PREDECESSOR = 15;
 
     /**
-     * (No doc, exported with reflection API)
+     * The job execution failed because it was aborted
      */
-    public const JOB_STATUS_FAILED = 32;
+    public const STATUS_FAILED_ABORTED = 16;
+
+    // Sorting options
 
     /**
-     * (No doc, exported with reflection API)
+     * Disable sorting of result set of getJobsList()
      */
-    public const JOB_STATUS_LOGICALLY_FAILED = 64;
-
-    /**
-     * (No doc, exported with reflection API)
-     */
-    public const JOB_STATUS_TIMEOUT = 128;
-
-    /**
-     * (No doc, exported with reflection API)
-     */
-    public const JOB_STATUS_REMOVED = 256;
-
-    /**
-     * (No doc, exported with reflection API)
-     */
-    public const JOB_STATUS_SCHEDULED = 512;
-
-    /**
-     * (No doc, exported with reflection API)
-     */
-    public const JOB_STATUS_SUSPENDED = 1024;
+    public const SORT_JOB_NONE = 0;
 
     /**
      * Disable sorting of result set of getJobsList()
@@ -285,6 +368,8 @@ class ZendJobQueue
      */
     public const SORT_BY_END_TIME = 13;
 
+    // Sort direction
+
     /**
      * Sort result set of getJobsList() in direct order
      */
@@ -294,6 +379,8 @@ class ZendJobQueue
      * Sort result set of getJobsList() in reverse order
      */
     public const SORT_DESC = 1;
+
+    // Other constants
 
     /**
      * Constant to report completion status from the jobs using setCurrentJobStatus()

--- a/src/ZendJobQueue.php
+++ b/src/ZendJobQueue.php
@@ -395,6 +395,58 @@ class ZendJobQueue
     private ZendPhpJQ\JobQueue $jobQueue;
 
     /**
+     * Checks if the Job Queue Daemon is running.
+     *
+     * @return bool Return true if the Job Queue Deamon is running, otherwise it returns false.
+     */
+    public static function isJobQueueDaemonRunning()
+    {
+        try {
+            new ZendPhpJQ\JobQueue();
+        } catch (ZendPhpJQ\Exception\NetworkError $e) {
+            return false;
+        } catch (ZendPhpJQ\Exception\LicenseError $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Decodes an array of input variables passed to the HTTP job.
+     *
+     * @return array The job variables.
+     */
+    public static function getCurrentJobParams()
+    {
+        return $_POST;
+    }
+
+    /**
+     * Reports job completion status (OK or FAILED) back to the daemon.
+     *
+     * @param int    $completion The job completion status (OK or FAILED).
+     * @param string $message The optional explanation message; ignored internally
+     */
+    public static function setCurrentJobStatus(int $completion, string $message = '')
+    {
+        http_response_code($completion === self::OK ? 200 : 500);
+    }
+
+    /**
+     * Returns the current job ID. Returns NULL if not called within a job context.
+     *
+     * The ZendHQ implementation does not support this. As such, this method
+     * returns null in all cases
+     *
+     * @return null|int
+     */
+    public static function getCurrentJobId()
+    {
+        return null;
+    }
+
+    /**
      * Creates a ZendJobQueue object connected to a Job Queue daemon.
      *
      * @param string $binding This value is accepted for backwards compatibility
@@ -444,6 +496,10 @@ class ZendJobQueue
             $legacyWorker ? ZendPhpJQ\HTTPJob::CONTENT_TYPE_ZEND_SERVER : ZendPhpJQ\HTTPJob::CONTENT_TYPE_URL_ENCODED
         );
 
+        if (isset($options['name'])) {
+            $job->setName($options['name']);
+        }
+
         $job->addHeader('User-Agent', 'Zend Server Job Queue');
 
         if (isset($options['headers'])) {
@@ -456,48 +512,76 @@ class ZendJobQueue
             $job->addBodyParam($key, $value);
         }
 
+        return $this->retrieveQueueFromOptions($options)
+            ->scheduleJob(
+                $job,
+                $this->createJobScheduleFromOptions($options),
+                $this->createJobOptions($options, $url, true)
+            )
+            ->getId();
+    }
+
+    /**
+     * Create a CLI job
+     *
+     * @param array $options Array of job options, containing any of the following:
+     *     - name: optional job name
+     *     - priority: job priority
+     *     - predecessor: integer predecessor job ID
+     *     - persistent: bool flag; keep in history forever
+     *     - schedule_time: time when job should be executed
+     *     - schedule: cron-like scheduling command
+     *     - job_timeout: timeout for the job
+     *     - queue_name: queue to which to assign job
+     *     - env: array of env vars to assign for script execution
+     *     - node_name: string node name where the script should run
+     * @return int ID of the generated job
+     */
+    public function createCliJob(string $command, array $options)
+    {
+        $job = new ZendPhpJQ\CLIJob($command);
+
         if (isset($options['name'])) {
             $job->setName($options['name']);
         }
 
-        $jobSchedule = null;
-        if (isset($options['schedule'])) {
-            $jobSchedule = new ZendPhpJQ\RecurringSchedule($options['schedule']);
-        } elseif (isset($options['schedule_time'])) {
-            $jobSchedule = new ZendPhpJQ\ScheduledTime(
-                DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $options['schedule_time'])
-            );
+        if (isset($options['env']) && is_array($options['env'])) {
+            foreach ($options['env'] as $key => $value) {
+                $job->setEnv((string) $key, (string) $value);
+            }
         }
 
-        if (isset($options['predecessor']) && ! empty($options['predecessor'])) {
-            error_log(
-                sprintf(
-                    'Job submission with url "%s" provides a "predecessor" option; '
-                    . 'predecessors are not supported in ZendHQ JobQueue at this time',
-                    $url
-                ),
-                E_USER_WARNING
-            );
-        }
+        return $this->retrieveQueueFromOptions($options)
+            ->scheduleJob(
+                $job,
+                $this->createJobScheduleFromOptions($options),
+                $this->createJobOptions($options, $command, false)
+            )
+            ->getId();
+    }
 
-        $jobOptions = new ZendPhpJQ\JobOptions(
-            $options['priority'] ?? null,
-            $options['job_timeout'] ?? null,
-            null,
-            null,
-            $options['persistent'] ?? ZendPhpJQ\JobOptions::PERSIST_OUTPUT_YES,
-            $options['validate_ssl'] ?? null
-        );
-
-        if (isset($options['queue_name']) && ! empty($options['queue_name'])) {
-            $queue = $this->jobQueue->hasQueue($options['queue_name'])
-                ? $this->jobQueue->addQueue($options['queue_name'])
-                : $this->jobQueue->getQueue($options['queue_name']);
-        } else {
-            $queue = $this->jobQueue->getDefaultQueue();
-        }
-
-        return $queue->scheduleJob($job, $jobSchedule, $jobOptions)->getId();
+    /**
+     * Create a CLI job to run via the installed PHP interpreter
+     *
+     * @param array $vars Array of arguments to pass to the script
+     * @param array $options Array of job options, containing any of the following:
+     *     - name: optional job name
+     *     - priority: job priority
+     *     - predecessor: integer predecessor job ID
+     *     - persistent: bool flag; keep in history forever
+     *     - schedule_time: time when job should be executed
+     *     - schedule: cron-like scheduling command
+     *     - job_timeout: timeout for the job
+     *     - queue_name: queue to which to assign job
+     *     - env: array of env vars to assign for script execution
+     *     - node_name: string node name where the script should run
+     * @return int ID of the generated job
+     */
+    public function createPhpCliJob(string $script, array $vars, array $options)
+    {
+        array_walk($vars, 'escapeshellarg');
+        $command = sprintf('%s %s', $script, implode(' ', $vars));
+        return $this->createCliJob($command, $options);
     }
 
     /**
@@ -505,7 +589,6 @@ class ZendJobQueue
      *
      * @param int $jobId A job ID.
      * @return array The array contains status, completion status and output of the job.
-     * @todo Remap job status returned to internal constants
      */
     public function getJobStatus(int $jobId)
     {
@@ -515,30 +598,9 @@ class ZendJobQueue
         }
 
         return [
-            'status' => $job->getStatus(), // TODO: remap job status
+            'status' => $this->mapJobStatusToConstant($job),
             'output' => $job->getOutput(),
         ];
-    }
-
-    /**
-     * Decodes an array of input variables passed to the HTTP job.
-     *
-     * @return array The job variables.
-     */
-    public static function getCurrentJobParams()
-    {
-        return $_POST;
-    }
-
-    /**
-     * Reports job completion status (OK or FAILED) back to the daemon.
-     *
-     * @param int    $completion The job completion status (OK or FAILED).
-     * @param string $message The optional explanation message; ignored internally
-     */
-    public static function setCurrentJobStatus(int $completion, string $message = '')
-    {
-        http_response_code($completion === self::OK ? 200 : 500);
     }
 
     /**
@@ -567,41 +629,21 @@ class ZendJobQueue
     }
 
     /**
-     * Restart a previously executed Job and all its followers.
-     *
-     * @param int $jobId A job ID
-     * @return bool If the job was restarted or not restarted.
-     */
-    public function restartJob(int $jobId)
-    {
-    }
-
-    /**
      * Checks if the Job Queue is suspended and returns true or false.
+     *
+     * This method returns true if any single ZendHQ JQ queue is suspended.
      *
      * @return bool A Job Queue status.
      */
     public function isSuspended()
     {
-    }
-
-    /**
-     * Checks if the Job Queue Daemon is running.
-     *
-     * @return bool Return true if the Job Queue Deamon is running, otherwise it returns false.
-     */
-    public static function isJobQueueDaemonRunning()
-    {
-        try {
-            $queue = $this->jobQueue->getDefaultQueue();
-            $queue->refresh();
-        } catch (ZendPhpJQ\Exception\NetworkError $e) {
-            return false;
-        } catch (ZendPhpJQ\Exception\LicenseError $e) {
-            return false;
+        foreach ($this->jobQueue->getQueues() as $queueName) {
+            if ($this->jobQueue->getQueue($queueName)->getStatus() === ZendPhpJQ\Queue::STATUS_SUSPENDED) {
+                return true;
+            }
         }
 
-        return true;
+        return false;
     }
 
     /**
@@ -611,6 +653,9 @@ class ZendJobQueue
      */
     public function suspendQueue()
     {
+        foreach ($this->jobQueue->getQueues() as $queueName) {
+            $this->jobQueue->getQueue($queueName)->suspend();
+        }
     }
 
     /**
@@ -618,6 +663,44 @@ class ZendJobQueue
      */
     public function resumeQueue()
     {
+        foreach ($this->jobQueue->getQueues() as $queueName) {
+            $queue = $this->jobQueue->getQueue($queueName);
+            if ($queue->getStatus() === ZendPhpJQ\Queue::STATUS_SUSPENDED) {
+                $queue->resume();
+            }
+        }
+    }
+
+    /**
+     * Restart a suspended job
+     *
+     * This method returns false in the following situations:
+     *
+     * - The job is not found
+     * - The job was not in a suspended state
+     * - The queue in which the job was found was not in a suspended state
+     *
+     * NOTE: Resuming the job means resuming the queue under ZendHQ.
+     */
+    public function restartJob(int $jobId): bool
+    {
+        $job = $this->getJobById($jobId);
+        if (null === $job) {
+            return false;
+        }
+
+        if ($job->getStatus() !== ZendPhpJQ\Job::STATUS_SUSPENDED) {
+            return false;
+        }
+
+        $queue = $this->jobQueue->getQueue($job->getQueueName());
+        if (! $queue->getStatus() === ZendPhpJQ\Queue::STATUS_SUSPENDED) {
+            return false;
+        }
+
+        $queue->resume();
+
+        return true;
     }
 
     /**
@@ -664,6 +747,8 @@ class ZendJobQueue
      *
      * The ZendHQ implementation does not support this. As such, this method
      * returns an empty array, and emits an E_USER_WARNING.
+     *
+     * @return array
      */
     public function getConfig()
     {
@@ -679,24 +764,55 @@ class ZendJobQueue
      * Returns the list of available queues.
      *
      * @return array
-     * @todo Need to munge the Queue instances into associative array of:
-     *     - queue name => 
-     *       - id
-     *       - name
-     *       - priority
-     *       - status
-     *       - max_http_jobs
-     *       - max_wait_time
-     *       - http_connection_timeout
-     *       - http_job_timeout
-     *       - http_job_retry_count
-     *       - http_job_retry_timeout
-     *       - running_jobs_count
-     *       - pending_jobs_count
+     * @psalm-return array<string, array{
+     *     id: int,
+     *     name: string,
+     *     priority: int,
+     *     status: int,
+     *     max_http_jobs: -1,
+     *     max_wait_time: int,
+     *     http_connection_timeout: int,
+     *     http_job_retry_count: int,
+     *     http_job_retry_timeout: int,
+     *     running_jobs_count: int,
+     *     pending_jobs_count: int,
+     * }>
      */
     public function getQueues()
     {
-        return $this->jobQueue->getQueues();
+        $queueNames = $this->jobQueue->getQueues();
+        $queues     = [];
+        foreach ($queueNames as $name) {
+            $queue       = $this->jobQueue->getQueue($name);
+            $definition  = $queue->getDefinition();
+            $defaults    = $definition->getDefaultJobOptions();
+            $timeout     = $defaults->getTimeout();
+            $retries     = $defaults->getAllowedRetries();
+            $waitTime    = $defaults->getRetryWaitTime();
+            $jobs        = $queue->getJobs();
+            $runningJobs = array_filter($jobs, function (Job $job): bool {
+                return $job->getStatus() === ZendPhpJQ\Job::STATUS_RUNNING;
+            });
+            $pendingJobs = array_filter($jobs, function (Job $job): bool {
+                return $job->getStatus() === ZendPhpJQ\Job::STATUS_SCHEDULED;
+            });
+
+            $queue[$name] = [
+                'id'                      => $queue->getId(),
+                'name'                    => $name,
+                'priority'                => $this->mapZendHQPriorityToZendServerPriority($queue->getPriority()),
+                'status'                  => $this->mapQueueStatusToConstant($queue),
+                'max_http_jobs'           => -1,
+                'max_wait_time'           => ($timeout * $retries) + (($retries - 1) * $waitTime),
+                'http_connection_timeout' => $defaults->getTimeout(),
+                'http_job_retry_count'    => $retries,
+                'http_job_retry_timeout'  => $waitTime,
+                'running_jobs_count'      => count($runningJobs),
+                'pending_jobs_count'      => count($pendingJobs),
+            ];
+        }
+
+        return $queues;
     }
 
     /**
@@ -745,26 +861,7 @@ class ZendJobQueue
             return [];
         }
 
-        return [
-            'id'         => $job->getId(),
-            'name'       => $job->getJobDefinition()->getName(),
-            'type'       => '', // The job type (see self::TYPE_* constants)
-            'status'     => $job->getStatus(),
-            'priority'   => $job->getJobOptions()->getPriority(),
-            'persistent' => $job->getJobOptions()->getPersistOutput(),
-            // "script" : The URL or SHELL script name
-            // "predecessor" : The job predecessor
-            'output'        => $job->getOutput(),
-            'creation_time' => $job->getCreationTime(),
-            'start_time'    => $job->getScheduledTime(),
-            'end_time'      => $job->getCompletionTime(),
-            // "vars" : The input variables or arguments
-            // "http_headers" : The additional HTTP headers for HTTP jobs
-            // "error" : The error output of the job
-            'schedule'      => $job->getSchedule(),
-            'schedule_time' => $job->getScheduledTime()->format('Y-m-d H:i:s'),
-            // "app_id" : The application name
-        ];
+        return $this->mapJobToInfoArray($job);
     }
 
     /**
@@ -789,7 +886,9 @@ class ZendJobQueue
     /**
      * Returns a list of associative arrays with properties of jobs which conform to a given query
      *
-     * @param array    $filter An associative array with query arguments.
+     * @see ZendJobQueue::getJob for details on how each job is presented in the returned list
+     *
+     * @param array    $filters An associative array with query arguments.
      *     The array may contain the following keys which restrict the resulting list:
      *     - "app_id" : Query only jobs which belong to the given application
      *     - "name" : Query only jobs with the given name
@@ -811,28 +910,36 @@ class ZendJobQueue
      *     "count" fields
      * @return array A list of jobs with their details
      */
-    public function getJobsList(array $filter = [], $total = null)
+    public function getJobsList(array $filters = [], &$total = null)
     {
-        $results = [];
-        foreach ($this->getQueues() as $queue) {
-            if (isset($filter['name'])) {
-                $results = array_merge($results, $queue->getJobsByName($filter['name']));
-                continue;
-            }
-
-            $results[] = $queue->getJobs();
+        $queues = $this->getQueuesBasedOnFilter($filters);
+        if (empty($queues)) {
+            return [];
         }
 
-        foreach ($results as $idx => $job) {
-            if (isset($filter['status']) && ($job->getStatus() !== $filter['status'])) {
-                unset($results[$idx]);
-                continue;
-            }
+        $jobs = $this->retrieveJobsByNameFilter($queues, $filters);
+        $jobs = $this->filterJobsByScript($jobs, $filters);
+        $jobs = $this->filterJobsByType($jobs, $filters);
+        $jobs = $this->filterJobsByPriority($jobs, $filters);
+        $jobs = $this->filterJobsByStatus($jobs, $filters);
+        $jobs = $this->filterJobsByScheduledBefore($jobs, $filters);
+        $jobs = $this->filterJobsByScheduledAfter($jobs, $filters);
+        $jobs = $this->filterJobsByExecutedBefore($jobs, $filters);
+        $jobs = $this->filterJobsByExecutedAfter($jobs, $filters);
 
-            // TODO: add other filtering parameters...
-        }
+        // Total count before applying start/count filters
+        $total = count($jobs);
 
-        return $results;
+        // Apply sorting rules
+        $jobs = $this->sortJobs($jobs, $filters);
+
+        // Apply slicing
+        $jobs = $this->sliceJobs($jobs, $filters);
+
+        // Munge to expected array information
+        return array_map(function (Job $job): array {
+            return $this->mapJobToInfoArray($job);
+        }, $jobs);
     }
 
     /**
@@ -871,65 +978,120 @@ class ZendJobQueue
      * - "last_run" - The last time the rule was run
      * - "next_run" - The next time the rule will run
      *
+     * The ZendHQ implementation does not support this. As such, this method
+     * returns an empty array, and emits an E_USER_WARNING.
+     *
      * @return array
      */
     public function getSchedulingRules()
     {
+        error_log(
+            sprintf('%s is unsupported in the Zend Server ZendJobQueue polyfill', __METHOD__),
+            E_USER_WARNING
+        );
+
+        return [];
     }
 
     /**
      * Returns an associative array with the properties of the scheduling rule
      * identified by the given argument. The list of the properties is the same
      * as in getSchedulingRules().
+     *
+     * The ZendHQ implementation does not support this. As such, this method
+     * returns an empty array, and emits an E_USER_WARNING.
+     *
+     * @return array
      */
     public function getSchedulingRule()
     {
+        error_log(
+            sprintf('%s is unsupported in the Zend Server ZendJobQueue polyfill', __METHOD__),
+            E_USER_WARNING
+        );
+
+        return [];
     }
 
     /**
      * Deletes the scheduling rule identified by the given $rule_id and
      * scheduled jobs created by this rule.
+     *
+     * The ZendHQ implementation does not support this. As such, this method
+     * returns false, and emits an E_USER_WARNING.
+     *
+     * @return false
      */
     public function deleteSchedulingRule()
     {
+        error_log(
+            sprintf('%s is unsupported in the Zend Server ZendJobQueue polyfill', __METHOD__),
+            E_USER_WARNING
+        );
+
+        return false;
     }
 
     /**
      * Suspends the scheduling rule identified by given $rule_id and deletes
      * scheduled jobs created by this rule.
+     *
+     * The ZendHQ implementation does not support this. As such, this method
+     * returns false, and emits an E_USER_WARNING.
+     *
+     * @return false
      */
     public function suspendSchedulingRule()
     {
+        error_log(
+            sprintf('%s is unsupported in the Zend Server ZendJobQueue polyfill', __METHOD__),
+            E_USER_WARNING
+        );
+
+        return false;
     }
 
     /**
      * Resumes the scheduling rule identified by given $rule_id and creates a
      * corresponding scheduled job.
+     *
+     * The ZendHQ implementation does not support this. As such, this method
+     * returns false, and emits an E_USER_WARNING.
+     *
+     * @return false
      */
     public function resumeSchedulingRule()
     {
+        error_log(
+            sprintf('%s is unsupported in the Zend Server ZendJobQueue polyfill', __METHOD__),
+            E_USER_WARNING
+        );
+
+        return false;
     }
 
     /**
      * Updates and reschedules the existing scheduling rule.
+     *
+     * The ZendHQ implementation does not support this. As such, this method
+     * returns false, and emits an E_USER_WARNING.
+     *
+     * @return false
      */
     public function updateSchedulingRule()
     {
-    }
+        error_log(
+            sprintf('%s is unsupported in the Zend Server ZendJobQueue polyfill', __METHOD__),
+            E_USER_WARNING
+        );
 
-    /**
-     * Returns the current job ID. Returns NULL if not called within a job context.
-     */
-    public static function getCurrentJobId()
-    {
+        return false;
     }
 
     /**
      * Get Job By Id
-     *
-     * @return ZendPhpJQ\Job|null
      */
-    private function getJobById(int $jobId)
+    private function getJobById(int $jobId): ?ZendPhpJQ\Job
     {
         foreach ($this->getQueues() as $queue) {
             try {
@@ -939,5 +1101,695 @@ class ZendJobQueue
         }
 
         return null;
+    }
+
+    private function createJobOptions(array $options, string $urlOrCommand, bool $isHttpJob): JobOptions
+    {
+        $jobOptions = new ZendPhpJQ\JobOptions(
+            $options['priority'] ?? null,
+            $options['job_timeout'] ?? null,
+            null,
+            null,
+            $options['persistent'] ?? ZendPhpJQ\JobOptions::PERSIST_OUTPUT_YES,
+            $options['validate_ssl'] ?? null
+        );
+
+        if (isset($options['predecessor']) && ! empty($options['predecessor'])) {
+            error_log(
+                sprintf(
+                    'Job submission with %s "%s" provides a "predecessor" option; '
+                    . 'predecessors are not supported in ZendHQ JobQueue at this time',
+                    $isHttpJob ? 'url' : 'command',
+                    $urlOrCommand
+                ),
+                E_USER_WARNING
+            );
+        }
+
+        if (isset($options['node_name']) && ! empty($options['node_name'])) {
+            error_log(
+                'Job submission specifying a node_name to run on is not supported in ZendHQ JobQueue at this time',
+                E_USER_WARNING
+            );
+        }
+
+        return $jobOptions;
+    }
+
+    private function createJobScheduleFromOptions(array $options): ?ZendPhpJQ\Schedule
+    {
+        if (isset($options['schedule'])) {
+            return new ZendPhpJQ\RecurringSchedule($options['schedule']);
+        }
+
+        if (isset($options['schedule_time'])) {
+            return new ZendPhpJQ\ScheduledTime(
+                DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $options['schedule_time'])
+            );
+        }
+
+        return null;
+    }
+
+    private function retrieveQueueFromOptions(array $options): ZendPhpJQ\Queue
+    {
+        if (! isset($options['queue_name']) || empty($options['queue_name'])) {
+            return $this->jobQueue->getDefaultQueue();
+        }
+
+        return $this->jobQueue->hasQueue($options['queue_name'])
+            ? $this->jobQueue->addQueue($options['queue_name'])
+            : $this->jobQueue->getQueue($options['queue_name']);
+    }
+
+    private function mapJobTypeToConstant(ZendPhpJQ\Job $job): int
+    {
+        if ($job->getJobDefinition() instanceof ZendPhpJQ\HTTPJob) {
+            return self::TYPE_HTTP;
+        }
+
+        return self::TYPE_CLI;
+    }
+
+    private function mapPriorityToConstant(ZendPhpJQ\Job $job): int
+    {
+        $priority = $job->getJobOptions()->getPriority();
+        switch (true) {
+            case $priority === ZendPhpJQ\Job::PRIORITY_LOW:
+                return self::PRIORITY_LOW;
+
+            case $priority === ZendPhpJQ\Job::PRIORITY_NORMAL:
+                return self::PRIORITY_NORMAL;
+
+            case $priority === ZendPhpJQ\Job::PRIORITY_HIGH:
+                return self::PRIORITY_HIGH;
+
+            case $priority === ZendPhpJQ\Job::PRIORITY_URGENT:
+                return self::PRIORITY_URGENT;
+        }
+    }
+
+    private function mapPersistenceToBoolean(ZendPhpJQ\Job $job): bool
+    {
+        $persistOutput = $job->getJobOptions()->getPersistOutput();
+        switch (true) {
+            case $persistOutput === ZendPhpJQ\Job::PERSIST_OUTPUT_YES:
+            case $persistOutput === ZendPhpJQ\Job::PERSIST_OUTPUT_ERROR:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private function mapJobStatusToConstant(ZendPhpJQ\Job $job): int
+    {
+        $status = $job->getStatus();
+        switch (true) {
+            case $status === ZendPHPJQ\Job::STATUS_CREATED:
+            case $status === ZendPHPJQ\Job::STATUS_SCHEDULED:
+                return self::STATUS_PENDING;
+
+            case $status === ZendPHPJQ\Job::STATUS_WAITING_ON_PARENT:
+                return self::STATUS_WAITING_PREDECESSOR;
+
+            case $status === ZendPHPJQ\Job::STATUS_RUNNING:
+                return self::STATUS_RUNNING;
+
+            case $status === ZendPHPJQ\Job::STATUS_SUSPENDED:
+                return self::STATUS_SUSPENDED;
+
+            case $status === ZendPHPJQ\Job::STATUS_TIMEOUT:
+                return self::STATUS_TIMEOUT;
+
+            case $status === ZendPHPJQ\Job::STATUS_FAILED_NO_WORKER:
+                return self::STATUS_FAILED_BACKEND;
+
+            case $status === ZendPHPJQ\Job::STATUS_FAILED_NO_WORKER:
+                return self::STATUS_FAILED_BACKEND;
+
+            case $status === ZendPHPJQ\Job::STATUS_FAILED_WORKER_ERROR:
+                return self::STATUS_LOGICALLY_FAILED;
+
+            case $status === ZendPHPJQ\Job::STATUS_REMOVED:
+                return self::STATUS_REMOVED;
+
+            case $status === ZendPHPJQ\Job::STATUS_COMPLETED:
+                return self::STATUS_COMPLETED;
+
+            default:
+                return self::STATUS_FAILED;
+        }
+    }
+
+    /**
+     * @return array Array of job details. The following properties are provided
+     *     (some of them don't have to always be set):
+     *     - "id" : The job identifier
+     *     - "type" : The job type (see self::TYPE_* constants)
+     *     - "status" : The job status (see self::STATUS_* constants)
+     *     - "priority" : The job priority (see self::PRIORITY_* constants)
+     *     - "persistent" : The persistence flag
+     *     - "script" : The URL or SHELL script name
+     *     - "predecessor" : The job predecessor
+     *     - "name" : The job name
+     *     - "vars" : The input variables or arguments
+     *     - "http_headers" : The additional HTTP headers for HTTP jobs
+     *     - "output" : The output of the job
+     *     - "error" : The error output of the job
+     *     - "creation_time" : The time when the job was created
+     *     - "start_time" : The time when the job was started
+     *     - "end_time" : The time when the job was finished
+     *     - "schedule" : The CRON-like schedule command
+     *     - "schedule_time" : The time when the job execution was scheduled
+     *     - "app_id" : The application name
+     */
+    private function mapJobToInfoArray(ZendPHPJQ\Job $job): array
+    {
+        $jobDefinition = $job->getJobDefinition();
+
+        $info = [
+            'id'            => $job->getId(),
+            'name'          => $jobDefinition()->getName(),
+            'type'          => $this->mapJobTypeToConstant($job),
+            'status'        => $this->mapJobStatusToConstant($job),
+            'priority'      => $this->mapPriorityToConstant($job),
+            'persistent'    => $this->mapPersistenceToBoolean($job),
+            'script'        => $jobDefinition instanceof ZendPhpJQ\HTTPJob
+                ? $jobDefinition->getUrl()
+                : $jobDefinition->getCommand(),
+            'predecessor'   => null,
+            'output'        => $job->getOutput(),
+            'creation_time' => $job->getCreationTime()->format('c'),
+            'start_time'    => $job->getScheduledTime()->format('c'),
+            'end_time'      => $job->getCompletionTime() ? $job->getCompletionTime->format('c') : null,
+            'schedule'      => $job->getSchedule(),
+            'schedule_time' => $job->getScheduledTime()->format('c'),
+            'app_id'        => null,
+        ];
+
+        if (null !== $job->getCompletionTime() && ZendPhpJQ\Job::STATUS_COMPLETED !== $job->getStatus()) {
+            $info['error'] = $job->getOutput();
+        }
+
+        if ($jobDefinition instanceof ZendPhpJQ\CLIJob) {
+            $info['vars'] = $jobDefinition()->getEnv();
+        }
+
+        if ($jobDefinition instanceof ZendPhpJQ\HTTPJob) {
+            $info['vars'] = [];
+            parse_str($jobDefinition->getBody(), $info['vars']);
+
+            $info['headers'] = $jobDefinition->getHeaders();
+        }
+
+        return $info;
+    }
+
+    /**
+     * Retrieve a list of queues based.
+     *
+     * If a `queue_name` value is present in the $filters, return an array with
+     * that queue (or an empty array if the queue does not exist). Otherwise, return
+     * a list of all queues.
+     *
+     * @return ZendPhpJQ\Queue[]
+     */
+    private function getQueuesBasedOnFilter(array $filters): array
+    {
+        if (isset($filters['queue_name']) && is_string($filters['queue_name'])) {
+            if (preg_match('/^\s*$/', $filters['queue_name'])) {
+                return [];
+            }
+
+            if (! $this->jobQueue->hasQueue($filters['queue_name'])) {
+                return [];
+            }
+
+            return $this->jobQueue->getQueue($filters['queue_name']);
+        }
+
+        $queues = [$this->jobQueue->getDefaultQueue()];
+        foreach ($this->jobQueue->getQueues() as $queueName) {
+            $queues[] = $this->jobQueue->getQueue($queueName);
+        }
+
+        return $queues;
+    }
+
+    /**
+     * Retrieve jobs from the list of queues based on the name.
+     *
+     * If $filters does not contain a "name" element, or that value is empty,
+     * this will return all jobs for the queues listed.
+     *
+     * @param ZendPhpJQ\Queue[] $queues
+     * @psalm-param array<string, string> $filters
+     * @return ZendPhpJQ\Job[]
+     */
+    private function retrieveJobsByNameFilter(array $queues, array $filters): array
+    {
+        $name = $filters['name'] ?? null;
+        $jobs = [];
+        foreach ($queues as $queue) {
+            $jobs = empty($name)
+                ? array_merge($jobs, $queue->getJobs())
+                : array_merge($jobs, $queue->getJobsByName($name));
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * Filter jobs by "script"
+     *
+     * If $filters does not contain a "script" element, or that value is empty,
+     * this is a no-op.
+     *
+     * @param ZendPhpJQ\Job[] $jobs
+     * @psalm-param array<string, string> $filters
+     * @return ZendPhpJQ\Job[]
+     */
+    private function filterJobsByScript(array $jobs, array $filters): array
+    {
+        if (! isset($filters['script']) || ! is_string($filters['script']) || empty($filters['script'])) {
+            return $jobs;
+        }
+
+        return array_filter($jobs, function (ZendPhpJQ\Job $job) use ($filters): bool {
+            $jobDefinition = $job->getJobDefinition();
+            if ($jobDefinition instanceof ZendPhpJQ\HTTPJob) {
+                return false !== stristr($jobDefinition->getUrl(), $filters['script']);
+            }
+
+            return false !== stristr($jobDefinition->getCommand(), $filters['script']);
+        });
+    }
+
+    /**
+     * Filter jobs by "type"
+     *
+     * If $filters does not contain a "type" element, or that value is not an
+     * integer, this is a no-op.
+     *
+     * @param ZendPhpJQ\Job[] $jobs
+     * @psalm-param array<string, string> $filters
+     * @return ZendPhpJQ\Job[]
+     */
+    private function filterJobsByType(array $jobs, array $filters): array
+    {
+        if (! isset($filters['type']) || ! is_int($filters['type'])) {
+            return $jobs;
+        }
+
+        return array_filter($jobs, function (ZendPhpJQ\Job $job) use ($filters): bool {
+            $jobDefinition = $job->getJobDefinition();
+
+            if ($filters['type'] & (self::JOB_TYPE_HTTP_RELATIVE + self::JOB_TYPE_HTTP)) {
+                return $jobDefinition instanceof ZendPhpJQ\HTTPJob;
+            }
+
+            if ($filters['type'] & self::JOB_TYPE_SHELL) {
+                return $jobDefinition instanceof ZendPhpJQ\CLIJob;
+            }
+
+            return false;
+        });
+    }
+
+    /**
+     * Filter jobs by "priority"
+     *
+     * If $filters does not contain a "priority" element, or that value is not an
+     * integer, this is a no-op.
+     *
+     * @param ZendPhpJQ\Job[] $jobs
+     * @psalm-param array<string, string> $filters
+     * @return ZendPhpJQ\Job[]
+     */
+    private function filterJobsByPriority(array $jobs, array $filters): array
+    {
+        if (! isset($filters['priority']) || ! is_int($filters['priority'])) {
+            return $jobs;
+        }
+
+        return array_filter($jobs, function (ZendPhpJQ\Job $job) use ($filters): bool {
+            $priority = $this->mapZendHQPriorityToZendServerPriority($job->getJobOptions()->getPriority());
+
+            return 0 !== $filters['priority'] & $priority;
+        });
+    }
+
+    private function mapZendHQPriorityToZendServerPriority(int $priority): int
+    {
+        switch (true) {
+            case $priority === ZendPhpJQ\JobOptions::PRIORITY_LOW:
+                return self::JOB_PRIORITY_LOW;
+
+            case $priority === ZendPhpJQ\JobOptions::PRIORITY_NORMAL:
+                return self::JOB_PRIORITY_NORMAL;
+
+            case $priority === ZendPhpJQ\JobOptions::PRIORITY_HIGH:
+                return self::JOB_PRIORITY_HIGH;
+
+            case $priority === ZendPhpJQ\JobOptions::PRIORITY_URGENT:
+                return self::JOB_PRIORITY_URGENT;
+
+            default:
+                return self::JOB_PRIORITY_NORMAL;
+        }
+    }
+
+    /**
+     * Filter jobs by "status"
+     *
+     * If $filters does not contain a "status" element, or that value is not an
+     * integer, this is a no-op.
+     *
+     * @param ZendPhpJQ\Job[] $jobs
+     * @psalm-param array<string, string> $filters
+     * @return ZendPhpJQ\Job[]
+     */
+    private function filterJobsByStatus(array $jobs, array $filters): array
+    {
+        if (! isset($filters['status']) || ! is_int($filters['status'])) {
+            return $jobs;
+        }
+
+        return array_filter($jobs, function (ZendPhpJQ\Job $job) use ($filters): bool {
+            $status = $this->mapJobStatusToConstant($job);
+
+            return 0 !== $filters['status'] & $status;
+        });
+    }
+
+    /**
+     * Filter jobs by "scheduled_before"
+     *
+     * If $filters does not contain a "scheduled_before" element, or that value
+     * can not be converted to a valid DateTimeImmutable instance, this is a
+     * no-op.
+     *
+     * @param ZendPhpJQ\Job[] $jobs
+     * @psalm-param array<string, string> $filters
+     * @return ZendPhpJQ\Job[]
+     */
+    private function filterJobsByScheduledBefore(array $jobs, array $filters): array
+    {
+        if (
+            ! isset($filters['scheduled_before'])
+            || (! is_int($filters['scheduled_before']) && ! is_string($filters['scheduled_before']))
+        ) {
+            return $jobs;
+        }
+
+        try {
+            $compare = new DateTimeImmutable($filters['scheduled_before']);
+        } catch (Exception $e) {
+            // Invalid comparison
+            error_log(
+                'Invalid scheduled_before value provided for getJobsList(); must be valid date-time string',
+                E_USER_WARNING
+            );
+            return $jobs;
+        }
+
+        return array_filter($jobs, function (ZendPhpJQ\Job $job) use ($compare): bool {
+            return $compare > $job->getScheduledTime();
+        });
+    }
+
+    /**
+     * Filter jobs by "scheduled_after"
+     *
+     * If $filters does not contain a "scheduled_after" element, or that value
+     * can not be converted to a valid DateTimeImmutable instance, this is a
+     * no-op.
+     *
+     * @param ZendPhpJQ\Job[] $jobs
+     * @psalm-param array<string, string> $filters
+     * @return ZendPhpJQ\Job[]
+     */
+    private function filterJobsByScheduledAfter(array $jobs, array $filters): array
+    {
+        if (
+            ! isset($filters['scheduled_after'])
+            || (! is_int($filters['scheduled_after']) && ! is_string($filters['scheduled_after']))
+        ) {
+            return $jobs;
+        }
+
+        try {
+            $compare = new DateTimeImmutable($filters['scheduled_after']);
+        } catch (Exception $e) {
+            // Invalid comparison
+            error_log(
+                'Invalid scheduled_after value provided for getJobsList(); must be valid date-time string',
+                E_USER_WARNING
+            );
+            return $jobs;
+        }
+
+        return array_filter($jobs, function (ZendPhpJQ\Job $job) use ($compare): bool {
+            return $compare < $job->getScheduledTime();
+        });
+    }
+
+    /**
+     * Filter jobs by "executed_before"
+     *
+     * If $filters does not contain a "executed_before" element, or that value
+     * can not be converted to a valid DateTimeImmutable instance, this is a
+     * no-op.
+     *
+     * @param ZendPhpJQ\Job[] $jobs
+     * @psalm-param array<string, string> $filters
+     * @return ZendPhpJQ\Job[]
+     */
+    private function filterJobsByExecutedBefore(array $jobs, array $filters): array
+    {
+        if (
+            ! isset($filters['executed_before'])
+            || (! is_int($filters['executed_before']) && ! is_string($filters['executed_before']))
+        ) {
+            return $jobs;
+        }
+
+        try {
+            $compare = new DateTimeImmutable($filters['executed_before']);
+        } catch (Exception $e) {
+            // Invalid comparison
+            error_log(
+                'Invalid executed_before value provided for getJobsList(); must be valid date-time string',
+                E_USER_WARNING
+            );
+            return $jobs;
+        }
+
+        return array_filter($jobs, function (ZendPhpJQ\Job $job) use ($compare): bool {
+            return $compare > $job->getCompletionTime();
+        });
+    }
+
+    /**
+     * Filter jobs by "executed_after"
+     *
+     * If $filters does not contain a "executed_after" element, or that value
+     * can not be converted to a valid DateTimeImmutable instance, this is a
+     * no-op.
+     *
+     * @param ZendPhpJQ\Job[] $jobs
+     * @psalm-param array<string, string> $filters
+     * @return ZendPhpJQ\Job[]
+     */
+    private function filterJobsByExecutedAfter(array $jobs, array $filters): array
+    {
+        if (
+            ! isset($filters['executed_after'])
+            || (! is_int($filters['executed_after']) && ! is_string($filters['executed_after']))
+        ) {
+            return $jobs;
+        }
+
+        try {
+            $compare = new DateTimeImmutable($filters['executed_after']);
+        } catch (Exception $e) {
+            // Invalid comparison
+            error_log(
+                'Invalid executed_after value provided for getJobsList(); must be valid date-time string',
+                E_USER_WARNING
+            );
+            return $jobs;
+        }
+
+        return array_filter($jobs, function (ZendPhpJQ\Job $job) use ($compare): bool {
+            return $compare < $job->getCompletionTime();
+        });
+    }
+
+    /**
+     * Sort jobs according to specified filters
+     *
+     * If $filters does not contain a "sort_by" element corresponding to one of
+     * the SORT_BY_* constants, this returns the jobs in an unspecified order.
+     *
+     * The following SORT_BY constants are ignored for purposes of sorting:
+     *
+     * - SORT_NONE
+     * - SORT_JOB_NONE
+     * - SORT_BY_APPLICATION
+     * - SORT_BY_PREDECESSOR
+     *
+     * If the "sort_direction" element is not present in $filters, SORT_ASC is
+     * assumed.
+     *
+     * @param ZendPhpJQ\Job[] $jobs
+     * @psalm-param array<string, string> $filters
+     * @return ZendPhpJQ\Job[]
+     */
+    private function sortJobs(array $jobs, array $filters): array
+    {
+        if (! isset($filters['sort_by']) || ! is_int($filters['sort_by'])) {
+            return $jobs;
+        }
+
+        $sortBy = $filters['sort_by'];
+        if (
+            ! in_array($sortBy, [
+                self::SORT_BY_ID,
+                self::SORT_BY_TYPE,
+                self::SORT_BY_SCRIPT,
+                self::SORT_BY_NAME,
+                self::SORT_BY_PRIORITY,
+                self::SORT_BY_STATUS,
+                self::SORT_BY_PERSISTENCE,
+                self::SORT_BY_SCHEDULE_TIME,
+                self::SORT_BY_START_TIME,
+                self::SORT_BY_END_TIME,
+            ], true)
+        ) {
+            return $jobs;
+        }
+
+        $sortDirection = $filters['sort_direction'] ?? self::SORT_ASC;
+        if (! in_array($sortDirection, [self::SORT_ASC, self::SORT_DESC], true)) {
+            $sortDirection = self::SORT_ASC;
+        }
+
+        usort($jobs, function (Job $a, Job $b) use ($sortBy, $sortDirection): int {
+            $aDefinition = $a->getJobDefinition();
+            $bDefinition = $b->getJobDefinition();
+
+            switch (true) {
+                case $sortBy === self::SORT_BY_ID:
+                    return $sortDirection === self::SORT_ASC
+                        ? $a->getId() <=> $b->getId()
+                        : $b->getId() <=> $a->getId();
+
+                case $sortBy === self::SORT_BY_TYPE:
+                    $aType = $aDefinition === ZendPhpJQ\CLIJob ? self::TYPE_CLI : self::TYPE_HTTP;
+                    $bType = $bDefinition === ZendPhpJQ\CLIJob ? self::TYPE_CLI : self::TYPE_HTTP;
+                    return $sortDirection === self::SORT_ASC
+                        ? $aType <=> $bType
+                        : $bType <=> $aType;
+
+                case $sortBy === self::SORT_BY_SCRIPT:
+                    $aScript = $aDefinition === ZendPhpJQ\CLIJob ? $aDefinition->getCommand() : $aDefinition->getUrl();
+                    $bScript = $bDefinition === ZendPhpJQ\CLIJob ? $bDefinition->getCommand() : $bDefinition->getUrl();
+                    return $sortDirection === self::SORT_ASC
+                        ? $aScript <=> $bScript
+                        : $bScript <=> $aScript;
+
+                case $sortBy === self::SORT_BY_NAME:
+                    return $sortDirection === self::SORT_ASC
+                        ? $aDefinition->getName() <=> $bDefinition->getName()
+                        : $bDefinition->getName() <=> $aDefinition->getName();
+
+                case $sortBy === self::SORT_BY_PRIORITY:
+                    $aPriority = $this->mapPriorityToConstant($a);
+                    $bPriority = $this->mapPriorityToConstant($b);
+                    return $sortDirection === self::SORT_ASC
+                        ? $aPriority <=> $bPriority
+                        : $bPriority <=> $aPriority;
+
+                case $sortBy === self::SORT_BY_STATUS:
+                    $aStatus = $this->mapJobStatusToConstant($a);
+                    $bStatus = $this->mapJobStatusToConstant($b);
+                    return $sortDirection === self::SORT_ASC
+                        ? $aStatus <=> $bStatus
+                        : $bStatus <=> $aStatus;
+
+                case $sortBy === self::SORT_BY_PERSISTENCE:
+                    return $sortDirection === self::SORT_ASC
+                        ? $aDefinition->getPersistOutput() <=> $bDefinition->getPersistOutput()
+                        : $bDefinition->getPersistOutput() <=> $aDefinition->getPersistOutput();
+
+                case $sortBy === self::SORT_BY_CREATION_TIME:
+                    return $sortDirection === self::SORT_ASC
+                        ? $a->getCreationTime() <=> $b->getCreationTime()
+                        : $b->getCreationTime() <=> $a->getCreationTime();
+
+                case $sortBy === self::SORT_BY_SCHEDULE_TIME:
+                case $sortBy === self::SORT_BY_START_TIME:
+                    return $sortDirection === self::SORT_ASC
+                        ? $a->getScheduledTime() <=> $b->getScheduledTime()
+                        : $b->getScheduledTime() <=> $a->getScheduledTime();
+
+                case $sortBy === self::SORT_BY_END_TIME:
+                    return $sortDirection === self::SORT_ASC
+                        ? $a->getCompletionTime() <=> $b->getCompletionTime()
+                        : $b->getCompletionTime() <=> $a->getCompletionTime();
+
+                default:
+                    return $sortDirection === self::SORT_ASC
+                        ? $a <=> $b
+                        : $b <=> $a;
+            }
+        });
+
+        return $jobs;
+    }
+
+    /**
+     * Return a slice of the jobs list based on the filters "start" and/or "count"
+     *
+     * @param ZendPhpJQ\Job[] $jobs
+     * @psalm-param array<string, string> $filters
+     * @return ZendPhpJQ\Job[]
+     */
+    private function sliceJobs(array $jobs, array $filters): array
+    {
+        $total = count($jobs);
+        $start = $filters['start'] ?? 0;
+        $start = (int) $start;
+
+        if ($start > $total) {
+            return [];
+        }
+
+        $count = $filters['count'] ?? null;
+        $count = null === $count ? null : (int) $count;
+
+        if ($start === 0 && (null !== $count && $count >= $total)) {
+            return $jobs;
+        }
+
+        return array_slice($jobs, $start, $count);
+    }
+
+    private function mapQueueStatusToConstant(ZendPhpJQ\Queue $queue): int
+    {
+        $status = $queue->getStatus();
+        switch (true) {
+            case $status === ZendPhpJQ\Queue::STATUS_SUSPENDED:
+                return self::STATUS_SUSPENDED;
+
+            case $status === ZendPhpJQ\Queue::STATUS_DELETED:
+                return self::STATUS_REMOVED;
+
+            case $status === ZendPhpJQ\Queue::STATUS_RUNNING:
+            default:
+                return self::STATUS_RUNNING;
+        }
     }
 }

--- a/src/ZendJobQueue.php
+++ b/src/ZendJobQueue.php
@@ -26,15 +26,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
- * @author    Slavey Karadzhov <skaradzhov@perforce.com>
  * @copyright 2023 Zend by Perforce
  * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
 use ZendHQ\JobQueue as ZendPhpJQ;
 
-if(!class_exists('ZendJobQueue')) {
-
+if (! class_exists('ZendJobQueue')) {
     class ZendJobQueue
     {
         /**
@@ -256,42 +254,36 @@ if(!class_exists('ZendJobQueue')) {
 
         private $binding;
 
-        /**
-         * @var ZendPhpJQ\JobQueue
-         */
+        /** @var ZendPhpJQ\JobQueue */
         private $jobQueue;
 
         /**
          * Creates a ZendJobQueue object connected to a Job Queue daemon.
-         *
-         * @param string $binding
          */
         public function __construct(string $binding = '')
         {
-            $this->binding = $binding;
+            $this->binding  = $binding;
             $this->jobQueue = new ZendPhpJQ\JobQueue();
         }
 
         /**
          * Creates a new URL based job to make the Job Queue Daemon call given $url with given $vars.
          *
-         *
          * @param string $url An absolute URL of the script to call.
-         * @param array $vars An associative array of variables which will be passed to the script. The total data size of this array should not be greater than the size defined in the zend_jobqueue.max_message_size directive.
-         * @param mixed $options An associative array of additional options. The elements of this array can define job priority, predecessor, persistence, optional name, additional attributes of HTTP request as HTTP headers, etc.
-         *               The following options are supported:
-         *               - "name" - Optional job name
-         *               - "priority" - Job priority (see corresponding constants)
-         *               - "predecessor" - Integer predecessor job id
-         *               - "persistent" - Boolean (keep in history forever)
-         *               - "schedule_time" - Time when job should be executed
-         *               - "schedule" - CRON-like scheduling command
-         *               - "http_headers" - Array of additional HTTP headers
-         *               - "job_timeout" - The timeout for the job
-         *               - "queue_name" - The queue assigned to the job
-         *               - "validate_ssl" - Boolean (validate ssl certificate")
-         * @param bool $legacyWorker set this parameter to true if the worker is running under real Zend Server.
-         *
+         * @param array  $vars An associative array of variables which will be passed to the script. The total data size of this array should not be greater than the size defined in the zend_jobqueue.max_message_size directive.
+         * @param mixed  $options An associative array of additional options. The elements of this array can define job priority, predecessor, persistence, optional name, additional attributes of HTTP request as HTTP headers, etc.
+         *                The following options are supported:
+         *                - "name" - Optional job name
+         *                - "priority" - Job priority (see corresponding constants)
+         *                - "predecessor" - Integer predecessor job id
+         *                - "persistent" - Boolean (keep in history forever)
+         *                - "schedule_time" - Time when job should be executed
+         *                - "schedule" - CRON-like scheduling command
+         *                - "http_headers" - Array of additional HTTP headers
+         *                - "job_timeout" - The timeout for the job
+         *                - "queue_name" - The queue assigned to the job
+         *                - "validate_ssl" - Boolean (validate ssl certificate")
+         * @param bool   $legacyWorker set this parameter to true if the worker is running under real Zend Server.
          * @return int A job ID which can be used to retrieve the job status.
          */
         public function createHttpJob(string $url, array $vars, $options, bool $legacyWorker = false)
@@ -301,10 +293,10 @@ if(!class_exists('ZendJobQueue')) {
                 ZendPhpJQ\HTTPJob::HTTP_METHOD_POST,
                 $legacyWorker ? ZendPhpJQ\HTTPJob::CONTENT_TYPE_ZEND_SERVER : ZendPhpJQ\HTTPJob::CONTENT_TYPE_URL_ENCODED
             );
-            $job->addHeader('User-Agent', 'Zend Server Job Queue') ;
-            if(isset($options['headers'])) {
+            $job->addHeader('User-Agent', 'Zend Server Job Queue');
+            if (isset($options['headers'])) {
                 foreach ($options['headers'] as $key => $value) {
-                    $job->addHeader($key, $value) ;
+                    $job->addHeader($key, $value);
                 }
             }
             foreach ($vars as $key => $value) {
@@ -315,7 +307,7 @@ if(!class_exists('ZendJobQueue')) {
                 $job->setName($options['name']);
             }
             $jobSchedule = null;
-            if(isset($options['schedule'])) {
+            if (isset($options['schedule'])) {
                 $jobSchedule = new ZendPhpJQ\RecurringSchedule($options['schedule']);
             } elseif (isset($options['schedule_time'])) {
                 $jobSchedule = new ZendPhpJQ\ScheduledTime(
@@ -351,8 +343,8 @@ if(!class_exists('ZendJobQueue')) {
 
             // TODO: remap job status
             return [
-                    'status' => $job->getStatus(), // TODO: remap job status
-                    'output' => $job->getOutput()
+                'status' => $job->getStatus(), // TODO: remap job status
+                'output' => $job->getOutput(),
             ];
         }
 
@@ -370,76 +362,63 @@ if(!class_exists('ZendJobQueue')) {
          * Reports job completion status (OK or FAILED) back to the daemon.
          *
          * @param int completion The job completion status (OK or FAILED).
-         * @param string $message The optional explanation message.
-         *
-         * @return void
+         * @param string                                                  $message The optional explanation message.
          */
         public static function setCurrentJobStatus(int $completion, string $message = '')
         {
-            http_response_code($completion == self::OK ? 200: 500);
+            http_response_code($completion == self::OK ? 200 : 500);
         }
 
         /**
          * Removes the job from the queue. Makes all dependent jobs fail. If the job is in progress, it will be finished, but dependent jobs will not be started. For non-existing jobs, the function returns false. Finished jobs are removed from the database.
          *
          * @param int $jobId A job ID
-         * @return boolean The job was removed or not removed.
+         * @return bool The job was removed or not removed.
          */
         public function removeJob(int $jobId)
         {
-
         }
 
         /**
-         *
          * Restart a previously executed Job and all its followers.
          *
          * @param int $jobId A job ID
-         * @return boolean - If the job was restarted or not restarted.
+         * @return bool - If the job was restarted or not restarted.
          */
         public function restartJob(int $jobId)
         {
-
         }
 
         /**
          * Checks if the Job Queue is suspended and returns true or false.
          *
-         * @return boolean A Job Queue status.
+         * @return bool A Job Queue status.
          */
         public function isSuspended()
         {
-
         }
 
         /**
          * Checks if the Job Queue Daemon is running.
          *
-         * @return boolean Return true if the Job Queue Deamon is running, otherwise it returns false.
+         * @return bool Return true if the Job Queue Deamon is running, otherwise it returns false.
          */
         public static function isJobQueueDaemonRunning()
         {
-
         }
 
         /**
          * Suspends the Job Queue so it will accept new jobs, but will not start them. The jobs which were executed during the call to this function will be completed.
-         *
-         * @return void
          */
         public function suspendQueue()
         {
-
         }
 
         /**
          * Resumes the Job Queue so it will schedule and start queued jobs.
-         *
-         * @return void
          */
         public function resumeQueue()
         {
-
         }
 
         /**
@@ -449,7 +428,6 @@ if(!class_exists('ZendJobQueue')) {
          */
         public function getStatistics()
         {
-
         }
 
         /**
@@ -460,17 +438,13 @@ if(!class_exists('ZendJobQueue')) {
          */
         public function getStatisticsByTimespan(int $timeSpan)
         {
-
         }
 
         /**
          * Returns the current value of the configuration option of the Job Queue Daemon.
-         *
-         * @return void
          */
         public function getConfig()
         {
-
         }
 
         /**
@@ -485,12 +459,9 @@ if(!class_exists('ZendJobQueue')) {
 
         /**
          * Re-reads the configuration file of the Job Queue Daemon, and reloads all directives that are reloadable.
-         *
-         * @return void
          */
         public function reloadConfig()
         {
-
         }
 
         /**
@@ -526,23 +497,23 @@ if(!class_exists('ZendJobQueue')) {
             }
 
             return [
-                'id' => $job->getId(),
-                'name' => $job->getJobDefinition()->getName(),
-                'type' => '', // The job type (see self::TYPE_* constants)
-                'status' => $job->getStatus(),
-                'priority' => $job->getJobOptions()->getPriority(),
+                'id'         => $job->getId(),
+                'name'       => $job->getJobDefinition()->getName(),
+                'type'       => '', // The job type (see self::TYPE_* constants)
+                'status'     => $job->getStatus(),
+                'priority'   => $job->getJobOptions()->getPriority(),
                 'persistent' => $job->getJobOptions()->getPersistOutput(),
                 // "script" : The URL or SHELL script name
                 // "predecessor" : The job predecessor
-                'output' => $job->getOutput(),
+                'output'        => $job->getOutput(),
                 'creation_time' => $job->getCreationTime(),
-                'start_time' => $job->getScheduledTime(),
-                'end_time' => $job->getCompletionTime(),
+                'start_time'    => $job->getScheduledTime(),
+                'end_time'      => $job->getCompletionTime(),
 //    *  - "vars" : The input variables or arguments
 //    *  - "http_headers" : The additional HTTP headers for HTTP jobs
 //
 //    *  - "error" : The error output of the job
-                'schedule' => $job->getSchedule(),
+                'schedule'      => $job->getSchedule(),
                 'schedule_time' => $job->getScheduledTime()->format('Y-m-d H:i:s'),
 //    *  - "app_id" : The application name
             ];
@@ -550,38 +521,35 @@ if(!class_exists('ZendJobQueue')) {
 
         /**
          * Returns a list of associative arrays with the properties of the jobs which depend on the job with the given identifier.
-         *
-         * @return void
          */
         public function getDependentJobs()
         {
-
         }
 
         /**
-             * Returns a list of associative arrays with properties of jobs which conform to a given query
+         * Returns a list of associative arrays with properties of jobs which conform to a given query
          *
-             * @param array $filter An associative array with query arguments.
-             * The array may contain the following keys which restrict the resulting list:
-             *  - "app_id" : Query only jobs which belong to the given application
-             *  - "name" : Query only jobs with the given name
-             *  - "script" : Query only jobs with a script name similar to the given one (SQL LIKE)
-             *  - "type" : Query only jobs of the given types (bitset)
-             *  - "priority" : Query only jobs with the given priorities (bitset)
-             *  - "status" : Query only jobs with the given statuses (bitset)
-             *  - "rule_id" : Query only jobs produced by the given scheduling rule
-             *  - "scheduled_before" : Query only jobs scheduled before the given date
-             *  - "scheduled_after" : Query only jobs scheduled after the given date
-             *  - "executed_before" : Query only jobs executed before the given date
-             *  - "executed_after" : Query only jobs executed after the given date
-             *  - "sort_by" : Sort by the given field (see self::SORT_BY_* constants)
-             *  - "sort_direction" : Sort the order (self::SORT_ASC or self::SORT_DESC)
-             *  - "start" : Skip the given number of jobs
-             *  - "count" : Retrieve only the given number of jobs (100 by default)
-             * @param int $total The output parameter which is set to the total number of jobs conforming to the given query, ignoring "start" and "count" fields
-             * @return array A list of jobs with their details
+         * @param array    $filter An associative array with query arguments.
+         *    The array may contain the following keys which restrict the resulting list:
+         *     - "app_id" : Query only jobs which belong to the given application
+         *     - "name" : Query only jobs with the given name
+         *     - "script" : Query only jobs with a script name similar to the given one (SQL LIKE)
+         *     - "type" : Query only jobs of the given types (bitset)
+         *     - "priority" : Query only jobs with the given priorities (bitset)
+         *     - "status" : Query only jobs with the given statuses (bitset)
+         *     - "rule_id" : Query only jobs produced by the given scheduling rule
+         *     - "scheduled_before" : Query only jobs scheduled before the given date
+         *     - "scheduled_after" : Query only jobs scheduled after the given date
+         *     - "executed_before" : Query only jobs executed before the given date
+         *     - "executed_after" : Query only jobs executed after the given date
+         *     - "sort_by" : Sort by the given field (see self::SORT_BY_* constants)
+         *     - "sort_direction" : Sort the order (self::SORT_ASC or self::SORT_DESC)
+         *     - "start" : Skip the given number of jobs
+         *     - "count" : Retrieve only the given number of jobs (100 by default)
+         * @param null|int $total The output parameter which is set to the total number of jobs conforming to the given query, ignoring "start" and "count" fields
+         * @return array A list of jobs with their details
          */
-        public function getJobsList(array $filter = array(), $total = null)
+        public function getJobsList(array $filter = [], $total = null)
         {
             $results = [];
             foreach ($this->getQueues() as $queue) {
@@ -607,12 +575,9 @@ if(!class_exists('ZendJobQueue')) {
 
         /**
          * Returns an array of application names known by the daemon.
-         *
-         * @return void
          */
         public function getApplications()
         {
-
         }
 
         /**
@@ -635,76 +600,60 @@ if(!class_exists('ZendJobQueue')) {
          */
         public function getSchedulingRules()
         {
-
         }
 
         /**
          * Returns an associative array with the properties of the scheduling rule identified by the given argument. The list of the properties is the same as in getSchedulingRules().
-         * @return void
          */
         public function getSchedulingRule()
         {
-
         }
 
         /**
          * Deletes the scheduling rule identified by the given $rule_id and scheduled jobs created by this rule.
-         * @return void
          */
         public function deleteSchedulingRule()
         {
-
         }
 
         /**
          * Suspends the scheduling rule identified by given $rule_id and deletes scheduled jobs created by this rule.
-         * @return void
          */
         public function suspendSchedulingRule()
         {
-
         }
-
 
         /**
          * Resumes the scheduling rule identified by given $rule_id and creates a corresponding scheduled job.
-         * @return void
          */
         public function resumeSchedulingRule()
         {
-
         }
 
         /**
          * Updates and reschedules the existing scheduling rule.
-         * @return void
          */
         public function updateSchedulingRule()
         {
-
         }
 
         /**
          * Returns the current job ID. Returns NULL if not called within a job context.
-         * @return void
          */
         public static function getCurrentJobId()
         {
-
         }
 
         /**
          * Get Job By Id
          *
-         * @param int $jobId
          * @return ZendPhpJQ\Job|null
          */
         private function getJobById(int $jobId)
         {
             foreach ($this->getQueues() as $queue) {
                 try {
-                    $job = $queue->getJob($jobId);
-                    return $job;
+                    return $queue->getJob($jobId);
                 } catch (ZendPhpJQ\InvalidArgument $ex) {
                 }
             }
@@ -712,5 +661,4 @@ if(!class_exists('ZendJobQueue')) {
             return null;
         }
     }
-
 } // if class exists

--- a/src/ZendJobQueue.php
+++ b/src/ZendJobQueue.php
@@ -625,33 +625,74 @@ class ZendJobQueue
      * jobs, number of failed jobs, number of logically failed jobs, number of
      * waiting jobs, number of currently running jobs, etc.
      *
+     * The ZendHQ implementation does not support this. As such, this method
+     * returns an empty array, and emits an E_USER_WARNING.
+     *
      * @return array Associative array.
      */
     public function getStatistics()
     {
+        error_log(
+            sprintf('%s is unsupported in the Zend Server ZendJobQueue polyfill', __METHOD__),
+            E_USER_WARNING
+        );
+
+        return [];
     }
 
     /**
      * See getStatistics API. Only checks jobs whose status were changed in a given timespan (seconds).
+     *
+     * The ZendHQ implementation does not support this. As such, this method
+     * returns an empty array, and emits an E_USER_WARNING.
      *
      * @param int $timeSpan The time span in seconds.
      * @return array Associative array.
      */
     public function getStatisticsByTimespan(int $timeSpan)
     {
+        error_log(
+            sprintf('%s is unsupported in the Zend Server ZendJobQueue polyfill', __METHOD__),
+            E_USER_WARNING
+        );
+
+        return [];
     }
 
     /**
      * Returns the current value of the configuration option of the Job Queue Daemon.
+     *
+     * The ZendHQ implementation does not support this. As such, this method
+     * returns an empty array, and emits an E_USER_WARNING.
      */
     public function getConfig()
     {
+        error_log(
+            sprintf('%s is unsupported in the Zend Server ZendJobQueue polyfill', __METHOD__),
+            E_USER_WARNING
+        );
+
+        return [];
     }
 
     /**
      * Returns the list of available queues.
      *
      * @return array
+     * @todo Need to munge the Queue instances into associative array of:
+     *     - queue name => 
+     *       - id
+     *       - name
+     *       - priority
+     *       - status
+     *       - max_http_jobs
+     *       - max_wait_time
+     *       - http_connection_timeout
+     *       - http_job_timeout
+     *       - http_job_retry_count
+     *       - http_job_retry_timeout
+     *       - running_jobs_count
+     *       - pending_jobs_count
      */
     public function getQueues()
     {
@@ -660,9 +701,15 @@ class ZendJobQueue
 
     /**
      * Re-reads the configuration file of the Job Queue Daemon, and reloads all directives that are reloadable.
+     *
+     * This is a no-op for the polyfill.
      */
     public function reloadConfig()
     {
+        error_log(
+            sprintf('%s is unsupported in the Zend Server ZendJobQueue polyfill', __METHOD__),
+            E_USER_WARNING
+        );
     }
 
     /**
@@ -723,9 +770,20 @@ class ZendJobQueue
     /**
      * Returns a list of associative arrays with the properties of the jobs
      * which depend on the job with the given identifier.
+     *
+     * The ZendHQ implementation does not support this. As such, this method
+     * returns an empty array, and emits an E_USER_WARNING.
+     *
+     * @return array
      */
     public function getDependentJobs()
     {
+        error_log(
+            sprintf('%s is unsupported in the Zend Server ZendJobQueue polyfill', __METHOD__),
+            E_USER_WARNING
+        );
+
+        return [];
     }
 
     /**
@@ -779,9 +837,20 @@ class ZendJobQueue
 
     /**
      * Returns an array of application names known by the daemon.
+     *
+     * The ZendHQ implementation does not support this. As such, this method
+     * returns an empty array, and emits an E_USER_WARNING.
+     *
+     * @return array
      */
     public function getApplications()
     {
+        error_log(
+            sprintf('%s is unsupported in the Zend Server ZendJobQueue polyfill', __METHOD__),
+            E_USER_WARNING
+        );
+
+        return [];
     }
 
     /**

--- a/src/ZendJobQueue.php
+++ b/src/ZendJobQueue.php
@@ -592,6 +592,16 @@ class ZendJobQueue
      */
     public static function isJobQueueDaemonRunning()
     {
+        try {
+            $queue = $this->jobQueue->getDefaultQueue();
+            $queue->refresh();
+        } catch (ZendPhpJQ\Exception\NetworkError $e) {
+            return false;
+        } catch (ZendPhpJQ\Exception\LicenseError $e) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/ZendJobQueue.php
+++ b/src/ZendJobQueue.php
@@ -505,6 +505,7 @@ class ZendJobQueue
      *
      * @param int $jobId A job ID.
      * @return array The array contains status, completion status and output of the job.
+     * @todo Remap job status returned to internal constants
      */
     public function getJobStatus(int $jobId)
     {
@@ -513,7 +514,6 @@ class ZendJobQueue
             return [];
         }
 
-        // TODO: remap job status
         return [
             'status' => $job->getStatus(), // TODO: remap job status
             'output' => $job->getOutput(),
@@ -534,7 +534,8 @@ class ZendJobQueue
      * Reports job completion status (OK or FAILED) back to the daemon.
      *
      * @param int    $completion The job completion status (OK or FAILED).
-     * @param string $message The optional explanation message.
+     * @param string $message The optional explanation message; ignored internally
+     * @return void
      */
     public static function setCurrentJobStatus(int $completion, string $message = '')
     {

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Zend Job Queue Polyfill
+ *
+ * In ZendPHP the Job Queue API has changed in comparison to Zend Server Job Queue API.
+ * This is a compatibility layer which allows applications running under ZendPHP to
+ * use the old Zend Server Job Queue API.
+ *
+ *
+ * LICENSE: Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @copyright 2023 Zend by Perforce
+ * @license   http://www.opensource.org/licenses/mit-license.html  MIT License
+ */
+
+if (! class_exists('ZendJobQueue')) {
+    require_once __DIR__ . '/ZendJobQueue.php';
+}


### PR DESCRIPTION
This patch ensures all methods found in reflection and published in the documentation are present and implemented.

The following methods have no corresponding functionality in the ZendHQ version, and have been implemented to (a) log a warning, and (b) return a sane default value:

- `getStatistics()`: This could potentially be implemented, as we can gather most of the information from the queues, but there is no documentation of what the actual structure returned is.
- `getStatisticsByTimespan()`: see previous.
- `getConfig()`: ZendHQ does not support querying for the configuration
- `reloadConfig()`: see previous.
- `getDependentJobs()`: ZendHQ does not support dependent jobs at this time.
- `getApplications()`: ZendHQ does not have a concept of an application; the assumption is that you will have a ZendHQ node _per_ application.
- `getSchedulingRules()`, `getSchedulingRule()`, `deleteSchedulingRule()`, `updateSchedulingRule()`, `suspendSchedulingRule()`, and `resumeSchedulingRule()`: ZendHQ keeps schedules per-job, instead of as separate entities. As such, these methods have no meaning under ZendHQ JQ.

Other operations are also not supported, and log warnings while continuing normally:

- The `node_name` option when creating a job is not supported in ZendHQ.
- The `predecessor` option when creating a job is not supported in ZendHQ.
- When retrieving jobs via `getJobsList()`, any of the date-time queries (scheduled_before, scheduled_after, executed_before, executed_after) will raise a warning if the date-time provided cannot be used to successfully create a DateTimeImmutable instance.

Additionally, there were a number of methods found via Reflection that were not in the documentation, and the assumption made was that these were from previous versions and considered deprecated; as such, I chose not to implement them:

- abortJob()
- createQueue()
- deleteQueue()
- getCurrentJobStatus()
- getStatisticsByQueues()
- resumeQueues()
- retroAnalyzeStats()
- runNowSchedulingRule()
- public static function setCurrentJobProgress()
- suspendQueues()

These can be added if we find customers using them.

Also with this patch, I did the following:

- Set the minimum PHP version to 7.2 (minimum that Zend currently supports via ZendHQ JQ)
- Replaced php-cs-fixer with the Laminas CS (superset of phpcs)
- Bumped the PHPUnit version
- Changed the autoloading to use file-based conditional autoloading instead of a class map. This approach is considered better in terms of CS (less indentation than with conditional classes).
